### PR TITLE
  Improve histogram binning in explorer and align client typings

### DIFF
--- a/client/src/pages/DatasetManage.tsx
+++ b/client/src/pages/DatasetManage.tsx
@@ -52,6 +52,13 @@ interface ColumnMetadata {
   suggested_chart: string
 }
 
+interface ColumnMetadataUpdate {
+  displayName?: string
+  description?: string
+  isHidden?: boolean
+  displayType?: string
+}
+
 function DatasetManage() {
   const { id } = useParams()
   const navigate = useNavigate()
@@ -177,7 +184,7 @@ function DatasetManage() {
     }
   }
 
-  const updateColumnMetadata = async (columnName: string, updates: Partial<ColumnMetadata>) => {
+  const updateColumnMetadata = async (columnName: string, updates: ColumnMetadataUpdate) => {
     if (!editingTableId) return
 
     try {

--- a/client/src/types/react-plotly-js.d.ts
+++ b/client/src/types/react-plotly-js.d.ts
@@ -1,0 +1,6 @@
+declare module 'react-plotly.js' {
+  import type { ComponentType } from 'react'
+
+  const Plot: ComponentType<any>
+  export default Plot
+}


### PR DESCRIPTION
  - adjust the explorer’s numeric histogram rebucketing so narrow ranges (e.g.
    0–1 scores) still render multiple bins using “nice” fractional widths
  - wire Plotly chart interactions through typed click/selection handlers to
    keep range filters accurate after rebucketing
  - add a lightweight react-plotly.js module declaration and tighten
    DatasetManage update typing so the TS build remains clean after the UI
    changes

