### PR TITLE
 Add MIT License to project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 BIAI Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/client/package.json
+++ b/client/package.json
@@ -26,9 +26,9 @@
     "typescript": "^5.5.3",
     "vite": "^5.4.1"
   },
-  "description": "",
+  "description": "BIAI Frontend - React-based UI for Business Intelligence AI",
   "main": "index.js",
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "BI AI Tool - Business Intelligence with AI capabilities",
   "private": true,
+  "license": "MIT",
   "workspaces": [
     "client",
     "server"

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,8 @@
   "name": "server",
   "version": "1.0.0",
   "type": "module",
+  "description": "BIAI Backend - API server for Business Intelligence AI",
+  "license": "MIT",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",


### PR DESCRIPTION
Summary

  Added MIT License to the project to establish clear open source licensing terms for contributors
  and users.

  Changes

  License File
  - Created LICENSE file in the root directory with standard MIT License text
  - Copyright attributed to "BIAI Contributors"

  Package Metadata Updates
  - Added "license": "MIT" field to root package.json
  - Updated client/package.json:
    - Added MIT license field
    - Improved description: "BIAI Frontend - React-based UI for Business Intelligence AI"
  - Updated server/package.json:
    - Added MIT license field
    - Improved description: "BIAI Backend - API server for Business Intelligence AI"

  Why MIT License?

  The MIT License is a permissive open source license that:
  - Allows commercial use
  - Permits modification and distribution
  - Requires copyright notice to be included in all copies
  - Provides no warranty
  - Is widely recognized and compatible with most other licenses

  Impact

  - Clarifies licensing terms for all contributors
  - Makes the project officially open source
  - Allows others to freely use, modify, and distribute the software
  - Protects contributors through the warranty disclaimer