### PR TITLE
Improve UX and large file handling for table imports

### DIFF
--- a/client/src/pages/DatasetManage.tsx
+++ b/client/src/pages/DatasetManage.tsx
@@ -70,7 +70,7 @@ function DatasetManage() {
   const [importMode, setImportMode] = useState<'file' | 'url'>('file')
   const [tableName, setTableName] = useState('')
   const [displayName, setDisplayName] = useState('')
-  const [skipRows, setSkipRows] = useState('4')
+  const [skipRows, setSkipRows] = useState('0')
   const [delimiter, setDelimiter] = useState('\t')
   const [primaryKey, setPrimaryKey] = useState('')
   const [uploading, setUploading] = useState(false)
@@ -150,6 +150,11 @@ function DatasetManage() {
       })
       setPreviewData(response.data.preview)
       setConfirmedRelationships(response.data.preview.detectedRelationships || [])
+
+      // Auto-detect skipRows if not manually set (still at default 0)
+      if (skipRows === '0' && response.data.preview.detectedSkipRows !== undefined) {
+        setSkipRows(String(response.data.preview.detectedSkipRows))
+      }
     } catch (error: any) {
       console.error('Preview failed:', error)
       setPreviewData(null)
@@ -204,14 +209,15 @@ function DatasetManage() {
     try {
       setUploading(true)
       await api.post(`/datasets/${id}/tables`, formData, {
-        headers: { 'Content-Type': 'multipart/form-data' }
+        headers: { 'Content-Type': 'multipart/form-data' },
+        timeout: 600000 // 10 minute timeout for large files
       })
       setShowAddTable(false)
       setSelectedFile(null)
       setFileUrl('')
       setTableName('')
       setDisplayName('')
-      setSkipRows('4')
+      setSkipRows('0')
       setPrimaryKey('')
       await loadDataset()
     } catch (error: any) {
@@ -472,7 +478,7 @@ function DatasetManage() {
                       value={fileUrl}
                       onChange={handleUrlChange}
                       onBlur={() => fileUrl && loadPreview(null, fileUrl)}
-                      placeholder="https://example.com/data.csv"
+                      placeholder=""
                       style={{ flex: 1, padding: '0.5rem', borderRadius: '4px', border: '1px solid #ddd' }}
                       required
                     />
@@ -507,7 +513,7 @@ function DatasetManage() {
                     value={tableName}
                     onChange={(e) => setTableName(e.target.value)}
                     required
-                    placeholder="e.g., patients"
+                    placeholder=""
                     style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ddd' }}
                   />
                 </div>
@@ -517,7 +523,7 @@ function DatasetManage() {
                     type="text"
                     value={displayName}
                     onChange={(e) => setDisplayName(e.target.value)}
-                    placeholder="e.g., Clinical Patients"
+                    placeholder=""
                     style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ddd' }}
                   />
                 </div>
@@ -553,7 +559,7 @@ function DatasetManage() {
                     type="text"
                     value={primaryKey}
                     onChange={(e) => setPrimaryKey(e.target.value)}
-                    placeholder="e.g., patient_id"
+                    placeholder=""
                     style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ddd' }}
                   />
                 </div>


### PR DESCRIPTION
## Summary

This PR improves the table import user experience with cleaner UI, intelligent skip row detection, and optimized handling of large files.

## Changes

### UX Improvements
- **Removed placeholder text** from all input fields for cleaner UI
  - Table Name, Display Name, Primary Key, and File URL fields now have empty placeholders
  - Less visual clutter and cleaner interface

### Smart Skip Row Detection
- **Auto-detects metadata rows** starting with `#` prefix
- Automatically sets skipRows based on file content
- Checks first 20 rows for `#` prefix
- Default skipRows changed from 4 to 0
- Users can still manually override the detected value

### Large File Handling

**Preview Performance**:
- Only reads first ~100 rows for preview (preview-only mode)
- Works efficiently even with multi-GB files
- Preview loads in seconds regardless of file size
- Stream destroyed early to free resources

**Import Optimization**:
- Increased file size limit from 50MB to 500MB
- Added 10-minute timeout for large file processing (both frontend and backend)
- Full file is read for actual import
- Better error handling for large files

## Technical Details

### Backend (`server/src/services/fileParser.ts`)
- Added `detectSkipRows()` function
  - Counts consecutive rows starting with `#`
  - Stops when first non-`#` row is found
- Added `previewOnly` parameter to `parseCSVFile()`
  - When true, stops reading after 100 rows
  - Destroys stream early to save memory
  - Default false for normal imports

### Backend (`server/src/routes/datasets.ts`)
- Preview endpoint uses `previewOnly: true` mode
- Returns `detectedSkipRows` in preview response
- Increased multer file size limit to 500MB
- Added 10-minute request timeouts
- Added fieldSize limit for URL uploads

### Frontend (`client/src/pages/DatasetManage.tsx`)
- Removed all placeholder text
- Auto-applies detected skipRows from backend
- Only auto-detects if user hasn't manually changed skipRows (still at 0)
- Added 10-minute axios timeout for imports
- Changed skipRows default from '4' to '0'

## Example Behavior

**File with metadata rows**:
```
#Sample ID
#Patient ID  
#Tumor Type
#Age
sample_id    patient_id    tumor_type    age
S001         P001          GBM           45
```
→ skipRows auto-set to 4

**File without metadata**:
```
sample_id    patient_id    tumor_type    age
S001         P001          GBM           45
```
→ skipRows remains 0

**Large file (500MB)**:
- Preview: Loads in seconds (only reads 100 rows)
- Import: Takes longer but completes successfully (10-minute timeout)

## Testing

- ✅ Tested with small files (auto-detection works)
- ✅ Tested with large files (preview loads fast)
- ✅ Tested with files containing # metadata rows
- ✅ Both client and server build successfully

## Files Changed

- `client/src/pages/DatasetManage.tsx` - UX improvements and timeout
- `server/src/routes/datasets.ts` - Large file handling and timeouts
- `server/src/services/fileParser.ts` - Preview mode and skip row detection

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)