### PR TITLE
Add table view for categorical columns (Issue #35)

### DIFF
--- a/server/src/services/columnAnalyzer.ts
+++ b/server/src/services/columnAnalyzer.ts
@@ -186,9 +186,10 @@ function detectDisplayType(
     }
   }
 
-  // Text columns (high cardinality)
+  // High cardinality categorical (was: text)
+  // Keep as categorical instead of text so they remain visible
   if (stats.unique_count > 100) {
-    return 'text'
+    return 'categorical'
   }
 
   // Default to categorical
@@ -225,15 +226,19 @@ function suggestChartType(
 
   // Categorical
   if (displayType === 'categorical') {
-    // Pie chart for few categories
+    // Pie chart for few categories (2-8)
     if (stats.unique_count >= 2 && stats.unique_count <= 8) {
       return 'pie'
     }
-    // Bar chart for more categories
+    // Bar chart for medium categories (9-50), but will default to table in UI
     if (stats.unique_count > 8 && stats.unique_count <= 50) {
       return 'bar'
     }
-    // Too many categories
+    // Bar chart for high cardinality too (will default to table in UI)
+    // Changed from 'none' to 'bar' so UI can toggle between chart and table
+    if (stats.unique_count > 50) {
+      return 'bar'
+    }
     return 'none'
   }
 
@@ -290,10 +295,8 @@ function shouldHideColumn(
     return true
   }
 
-  // Hide text columns
-  if (displayType === 'text') {
-    return true
-  }
+  // Don't hide text columns anymore - they'll be shown as tables
+  // (Removed text column hiding)
 
   // Hide if mostly null (>90%)
   const nullPercent = (stats.null_count / stats.total_count) * 100


### PR DESCRIPTION
## Summary
Implements Issue #35 - adds table view option for categorical columns to display high-cardinality data efficiently.

## Changes

### Backend (columnAnalyzer.ts)
- Keep high-cardinality columns (>100 unique values) as `categorical` instead of `text`
- Remove hiding of high-cardinality columns
- Set `suggested_chart` to `bar` for all categorical columns to enable toggle functionality

### Frontend (DatasetExplorer.tsx)
- **Table view component**: Displays category | count | percentage with sortable data
- **Toggle buttons**: ⊞/◐ to switch between chart and table views
- **Smart defaults**: Table view for >8 categories, chart view for ≤8
- **View preferences**: Persisted in localStorage per dataset
- **Interactive filtering**: Click table rows to filter by category
- **First 100 rows**: Shows first 100 categories with indicator if more exist
- **Optimized grid layout**:
  - CSS Grid with dense packing algorithm
  - Tables: 358×358px spanning 2×2 grid cells
  - Bar charts/histograms: 358×175px spanning 2 columns
  - Pie charts: 175×175px in single grid cell
  - Efficient space utilization with gap filling

## Test plan
- [x] Backend changes compile and server starts successfully
- [x] Frontend changes compile and hot-reload works
- [x] Table view renders correctly with category, count, and percentage columns
- [x] Toggle buttons switch between chart and table views
- [x] View preferences persist across page reloads
- [x] Table rows are clickable for filtering
- [x] Grid layout packs efficiently without overlapping
- [x] Tables span 2×2 grid cells as expected
- [ ] Re-upload dataset to test high-cardinality columns like hugo_symbols appear
- [ ] Verify filtering works correctly from table view

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)