### PR TITLE
MVP1: add parent count mode to Explorer

### DIFF
--- a/server/src/routes/databases.ts
+++ b/server/src/routes/databases.ts
@@ -338,8 +338,12 @@ router.get('/:database/tables/:table/aggregations', async (req, res) => {
         const aggregations = await aggregationService.getTableAggregations(datasetId, table, filters, countByConfig)
         return res.json({ aggregations })
       } catch (error: any) {
+        const status = error?.status || 500
         console.error('Get database aggregations error:', error)
-        return res.status(500).json({ error: 'Failed to get table aggregations', message: error.message })
+        return res.status(status).json({
+          error: status === 400 ? 'Invalid countBy parameter' : 'Failed to get table aggregations',
+          message: error.message
+        })
       }
     }
 

--- a/server/src/routes/datasets.ts
+++ b/server/src/routes/datasets.ts
@@ -600,8 +600,12 @@ router.get('/:id/tables/:tableId/aggregations', async (req, res) => {
       aggregations
     })
   } catch (error: any) {
+    const status = error?.status || 500
     console.error('Get table aggregations error:', error)
-    return res.status(500).json({ error: 'Failed to get table aggregations', message: error.message })
+    return res.status(status).json({
+      error: status === 400 ? 'Invalid countBy parameter' : 'Failed to get table aggregations',
+      message: error.message
+    })
   }
 })
 
@@ -635,8 +639,12 @@ router.get('/:id/tables/:tableId/columns/:columnName/aggregation', async (req, r
       aggregation
     })
   } catch (error: any) {
+    const status = error?.status || 500
     console.error('Get column aggregation error:', error)
-    return res.status(500).json({ error: 'Failed to get column aggregation', message: error.message })
+    return res.status(status).json({
+      error: status === 400 ? 'Invalid countBy parameter' : 'Failed to get column aggregation',
+      message: error.message
+    })
   }
 })
 

--- a/server/src/utils/countBy.ts
+++ b/server/src/utils/countBy.ts
@@ -1,5 +1,15 @@
 import type { CountByConfig } from '../services/aggregationService.js'
 
+/**
+ * Parse the `countBy` query parameter into a configuration object.
+ *
+ * Supported formats:
+ *   - undefined, '', or 'rows' → default row counting
+ *   - 'parent:<table_name>' → count distinct values of the referenced table
+ *
+ * @param raw Raw query string value (e.g. "parent:patients")
+ * @returns Parsed configuration or an error string when invalid
+ */
 export function parseCountByQuery(raw?: string): { config?: CountByConfig; error?: string } {
   if (!raw) {
     return { config: undefined }


### PR DESCRIPTION
## Summary
- add backend countBy parameter and metric metadata
- add per-table count-by selector with persistence
- update charts/tables (including histogram scaling) to respect parent counts and disable pies when needed

## Testing
- npm run test --workspace=client -- DatasetExplorer
- npm run test --workspace=server (fails: existing dataset/ClickHouse mocks expect legacy behavior)

Fix #50 