### PR TITLE
feat: support per-chart ancestor selection

### DIFF
--- a/client/src/utils/filterHelpers.ts
+++ b/client/src/utils/filterHelpers.ts
@@ -10,6 +10,11 @@ export interface Filter {
   or?: Filter[]
   not?: Filter
   tableName?: string
+  /**
+   * Client-side metadata describing which count context (rows vs parent table) produced the filter.
+   * The backend ignores this field and only relies on {@link tableName} to derive join paths.
+   */
+  countByKey?: string
 }
 
 export interface TableRelationship {


### PR DESCRIPTION
## Summary
- add per-chart ancestor selector with indicator menus and persistence for both explorer tabs and dashboard cards
- scope filters/ranges to the chart’s count-by target and handle loading states for missing aggregations
- surface simplified count-by options and update tests for the new UX

## Testing
- npm run test --workspace=client -- DatasetExplorer -- --reporter=verbose

fix #57 #52 