### PR TITLE
Fix: Remove unused variable and add count-by text for accessibility

### DIFF
--- a/client/src/pages/DatasetExplorer.tsx
+++ b/client/src/pages/DatasetExplorer.tsx
@@ -5290,7 +5290,6 @@ const renderNumericFilterMenu = (
         const metricLabels = getMetricLabels(primaryAggregation)
         const parentOptions = ancestorOptions[table.name] || []
         const countByValue = getCountByValueForTable(table.name)
-        const countOptions = getCountByOptions(table.name)
 
         return (
           <div key={table.name} style={{ marginBottom: '2.5rem' }}>
@@ -5349,9 +5348,13 @@ const renderNumericFilterMenu = (
                           {baselineRowCount > 0 ? ((tableRowCount / baselineRowCount) * 100).toFixed(1) : '0'}%
                         </span>
                         <span> {metricLabels.short} · {visibleAggregations.length} columns</span>
+                        <span style={{ color: '#999', fontSize: '0.75rem' }}> (by {getCountByLabelFromCacheKey(table.name, countByValue)})</span>
                       </>
                     ) : (
-                      <>{tableRowCount.toLocaleString()} {metricLabels.short} · {visibleAggregations.length} columns</>
+                      <>
+                        {tableRowCount.toLocaleString()} {metricLabels.short} · {visibleAggregations.length} columns
+                        <span style={{ color: '#999', fontSize: '0.75rem' }}> (by {getCountByLabelFromCacheKey(table.name, countByValue)})</span>
+                      </>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
This PR fixes two critical issues introduced in PR #66:
1. **Build error**: Removes unused `countOptions` variable that breaks compilation with `noUnusedLocals`
2. **Accessibility regression**: Adds text indication of selected count-by table

## Issues Fixed

### Issue 1: Build Error - Unused Variable
**Problem**: Line 5293 declared `const countOptions = getCountByOptions(table.name)` which is no longer used after removing the dropdown selector.

**Impact**: With `noUnusedLocals` enabled in `client/tsconfig.json`, `tsc --noEmit` fails, breaking the build.

**Fix**: Removed the unused variable declaration. The `renderTabCountIndicator()` function calls `getCountByOptions()` internally, making the outer declaration redundant.

### Issue 2: Accessibility Regression - Missing Text Indication
**Problem**: Replacing the dropdown with a color-only indicator removed textual display of which ancestor table is currently selected.

**Impact**:
- Color-blind users cannot identify the selected table
- Multiple tables may share the same palette color
- Users must click/guess to know current selection state
- Violates accessibility best practices (WCAG)

**Fix**: Added text label showing current count-by selection inline with row/column count.

## Changes Made

### 1. Removed Unused Variable ([DatasetExplorer.tsx:5293](client/src/pages/DatasetExplorer.tsx#L5293))
```diff
  const metricLabels = getMetricLabels(primaryAggregation)
  const parentOptions = ancestorOptions[table.name] || []
  const countByValue = getCountByValueForTable(table.name)
- const countOptions = getCountByOptions(table.name)
```

### 2. Added Count-By Text Label ([DatasetExplorer.tsx:5351,5356](client/src/pages/DatasetExplorer.tsx#L5351))
Added `(by TableName)` text after row/column count in both filtered and unfiltered states.

**Filtered state (with baseline comparison)**:
```jsx
<span> {metricLabels.short} · {visibleAggregations.length} columns</span>
<span style={{ color: '#999', fontSize: '0.75rem' }}> (by {getCountByLabelFromCacheKey(table.name, countByValue)})</span>
```

**Unfiltered state**:
```jsx
{tableRowCount.toLocaleString()} {metricLabels.short} · {visibleAggregations.length} columns
<span style={{ color: '#999', fontSize: '0.75rem' }}> (by {getCountByLabelFromCacheKey(table.name, countByValue)})</span>
```

## Visual Examples

**Before (accessibility issue)**:
```
data_clinical_sample
61 rows · 9 columns
[Blue indicator only - no text]
```

**After (accessible)**:
```
data_clinical_sample
61 rows · 9 columns (by Rows)
[Blue indicator]
```

**When counting by parent table**:
```
data_clinical_sample
42 unique patients · 9 columns (by Patients)
[Blue indicator with green border]
```

## Design Decisions

### Text Styling
- **Color**: `#999` (light gray) to be subtle and not compete with primary metrics
- **Font size**: `0.75rem` (smaller than the 0.8rem row count text)
- **Format**: `(by TableName)` - concise and clear
- **Placement**: Inline after row/column count - keeps related info together

### Why Inline Instead of Separate Line
- More compact, doesn't increase vertical space
- Keeps count-by context close to the metrics it affects
- Maintains visual hierarchy (primary info → secondary info)

## Accessibility Benefits

1. **Screen readers**: Text is properly read aloud with count metrics
2. **Color-blind users**: Can identify selection without relying on color
3. **Cognitive load**: Explicit text reduces need to decode color meanings
4. **WCAG compliance**: Meets "Don't rely on color alone" guideline

## Testing

- [x] Verify build succeeds with `noUnusedLocals` enabled
- [x] Verify text appears in both filtered and unfiltered states
- [x] Verify text shows correct table name for row counts and parent counts
- [x] Verify text styling is subtle and readable
- [x] Verify color indicator still works alongside text

## Related

- PR #66 (introduced these issues)
- Issue #65 (original enhancement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)