### PR TITLE
feat: add dual-color coding to filter chips

### DIFF
--- a/client/src/pages/DatasetExplorer.tsx
+++ b/client/src/pages/DatasetExplorer.tsx
@@ -4063,6 +4063,10 @@ const renderNumericFilterMenu = (
               const tableColor = tableName ? getTableColor(tableName) : '#9E9E9E'
               const table = dataset?.tables.find(t => t.name === tableName)
 
+              // Extract count-by table for border color
+              const countByTable = targetFromCacheKey(filter.countByKey)
+              const countByColor = countByTable ? getTableColor(countByTable) : tableColor
+
               let displayValue = String(actualFilter.value)
               let logicType = '' // For tooltip
 
@@ -4158,7 +4162,9 @@ const renderNumericFilterMenu = (
                       display: 'flex',
                       alignItems: 'center',
                       gap: '0.5rem',
-                      border: isNot ? `2px dashed ${tableColor}` : `2px solid ${tableColor}`,
+                      outline: `4px solid ${countByColor}`,
+                      outlineOffset: '2px',
+                      border: isNot ? `2px dashed rgba(255,255,255,0.6)` : 'none',
                       color: 'white',
                       fontWeight: 500,
                       opacity: isNot ? 0.9 : 1


### PR DESCRIPTION
## Summary

Implements dual-color coding for filter chips in the Active Filters section to visually distinguish between:
- The table being filtered (background color)
- The count-by context that created the filter (outline color)

## Changes

- Extract count-by table from `filter.countByKey` using `targetFromCacheKey()`
- Apply filter table color to background
- Apply count-by table color to outline (4px solid with 2px offset)
- Update NOT filter border to use semi-transparent white dashed line

## Visual Examples

**Row-level filter** (counting by rows):
- Background: table color
- Outline: same table color (since count-by is rows, falls back to table color)

**Parent-table filter** (counting by parent):
- Background: filtered table color
- Outline: parent table color (different from background)

## Test Plan

- [x] Verify row-level filters show same color for background and outline
- [x] Verify parent-table filters show different colors (background vs outline)
- [x] Verify NOT filters maintain gradient appearance with new outline
- [x] Verify colors match the table color palette used elsewhere in the UI

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)