### PR TITLE
fix(security): prevent SQL injection in ClickHouse queries

### DIFF
--- a/server/src/__tests__/security/sqlInjection.test.ts
+++ b/server/src/__tests__/security/sqlInjection.test.ts
@@ -1,0 +1,242 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import {
+  validateIdentifier,
+  validateIdentifierFormat,
+  escapeIdentifier,
+  ensurePositiveInteger,
+  escapeStringValue
+} from '../../utils/sqlSanitizer'
+
+/**
+ * SQL Injection Security Tests
+ *
+ * These tests verify that the SQL sanitizer functions properly block
+ * common SQL injection attack vectors used against ClickHouse.
+ */
+describe('SQL Injection Prevention', () => {
+  describe('Classic SQL Injection Attacks', () => {
+    const validColumns = new Set(['id', 'name', 'email', 'status'])
+
+    const classicAttacks = [
+      "'; DROP TABLE users; --",
+      "' OR '1'='1",
+      "' OR 1=1 --",
+      "' UNION SELECT * FROM users --",
+      "1; DELETE FROM users",
+      "admin'--",
+      "' OR 1=1 #",
+      "') OR ('1'='1",
+      "1' ORDER BY 1--",
+      "1' ORDER BY 2--",
+      "' AND '1'='1",
+      "' AND SLEEP(5)--",
+      "'-'",
+      "' '",
+      "'&'",
+      "'^'",
+      "'*'",
+    ]
+
+    test.each(classicAttacks)('blocks classic attack: %s', (attack) => {
+      expect(() => validateIdentifier(attack, validColumns)).toThrow()
+    })
+  })
+
+  describe('ClickHouse-Specific Attacks', () => {
+    const validColumns = new Set(['id', 'name'])
+
+    const clickhouseAttacks = [
+      "id`; DROP TABLE users",         // Backtick injection
+      "id); SELECT * FROM system.tables",
+      "id SETTINGS log_queries=1",     // Settings injection
+      "id FORMAT JSONEachRow",         // Format injection
+      "id INTO OUTFILE '/tmp/out'",    // File write attempt
+      "id FROM file('/etc/passwd')",   // File read attempt
+    ]
+
+    test.each(clickhouseAttacks)('blocks ClickHouse attack: %s', (attack) => {
+      expect(() => validateIdentifier(attack, validColumns)).toThrow()
+    })
+  })
+
+  describe('Comment-Based Injection', () => {
+    const validColumns = new Set(['id'])
+
+    const commentAttacks = [
+      "id/*comment*/",
+      "id--comment",
+      "id#comment",
+      "id/* */OR/* */1=1",
+      "id/**/UNION/**/SELECT/**/password",
+    ]
+
+    test.each(commentAttacks)('blocks comment attack: %s', (attack) => {
+      expect(() => validateIdentifier(attack, validColumns)).toThrow()
+    })
+  })
+
+  describe('Whitespace and Encoding Attacks', () => {
+    const validColumns = new Set(['id'])
+
+    const encodingAttacks = [
+      "id\nUNION SELECT",              // Newline injection
+      "id\rDELETE FROM",               // Carriage return
+      "id\tOR 1=1",                    // Tab injection
+      "id%27",                         // URL encoded quote
+      "id%00",                         // Null byte
+      "id\x00",                        // Null char
+    ]
+
+    test.each(encodingAttacks)('blocks encoding attack: %s', (attack) => {
+      expect(() => validateIdentifier(attack, validColumns)).toThrow()
+    })
+  })
+
+  describe('LIMIT/OFFSET Injection', () => {
+    const limitAttacks = [
+      '1; DROP TABLE users',
+      '1 OR 1=1',
+      '1--',
+      '1/*comment*/',
+      '-1',
+      'SLEEP(5)',
+      '1e10',
+      '0x10',
+      'null',
+      'undefined',
+      'NaN',
+      'Infinity',
+      '1.5',
+      '1,000',
+      '1_000',
+    ]
+
+    test.each(limitAttacks)('blocks LIMIT injection: %s', (attack) => {
+      expect(() => ensurePositiveInteger(attack, 'limit')).toThrow()
+    })
+
+    test('accepts valid integers', () => {
+      expect(ensurePositiveInteger(0, 'limit')).toBe(0)
+      expect(ensurePositiveInteger(1, 'limit')).toBe(1)
+      expect(ensurePositiveInteger(100, 'limit')).toBe(100)
+      expect(ensurePositiveInteger('50', 'offset')).toBe(50)
+    })
+  })
+
+  describe('Identifier Escaping', () => {
+    test('properly escapes valid identifiers with backticks', () => {
+      expect(escapeIdentifier('column_name')).toBe('`column_name`')
+      expect(escapeIdentifier('_private')).toBe('`_private`')
+      expect(escapeIdentifier('Table123')).toBe('`Table123`')
+    })
+
+    test('rejects identifiers with special characters', () => {
+      expect(() => escapeIdentifier("col'name")).toThrow()
+      expect(() => escapeIdentifier('col"name')).toThrow()
+      expect(() => escapeIdentifier('col`name')).toThrow()
+      expect(() => escapeIdentifier('col;name')).toThrow()
+      expect(() => escapeIdentifier('col--name')).toThrow()
+    })
+
+    test('rejects identifiers starting with numbers', () => {
+      expect(() => escapeIdentifier('123col')).toThrow()
+      expect(() => escapeIdentifier('1table')).toThrow()
+    })
+  })
+
+  describe('String Value Escaping', () => {
+    test('escapes single quotes', () => {
+      expect(escapeStringValue("O'Brien")).toBe("O\\'Brien")
+      expect(escapeStringValue("it's")).toBe("it\\'s")
+      expect(escapeStringValue("''")).toBe("\\'\\'")
+    })
+
+    test('escapes backslashes', () => {
+      expect(escapeStringValue('path\\to\\file')).toBe('path\\\\to\\\\file')
+    })
+
+    test('handles combined escapes', () => {
+      expect(escapeStringValue("path\\to\\'file")).toBe("path\\\\to\\\\\\'file")
+    })
+
+    test('blocks non-string values', () => {
+      expect(() => escapeStringValue(123 as any)).toThrow()
+      expect(() => escapeStringValue(null as any)).toThrow()
+      expect(() => escapeStringValue(undefined as any)).toThrow()
+    })
+  })
+
+  describe('Identifier Format Validation', () => {
+    test('accepts valid formats', () => {
+      expect(validateIdentifierFormat('column_name')).toBe('column_name')
+      expect(validateIdentifierFormat('_private')).toBe('_private')
+      expect(validateIdentifierFormat('Column123')).toBe('Column123')
+      expect(validateIdentifierFormat('a')).toBe('a')
+      expect(validateIdentifierFormat('A')).toBe('A')
+    })
+
+    test('rejects invalid formats', () => {
+      expect(() => validateIdentifierFormat('123start')).toThrow()
+      expect(() => validateIdentifierFormat('has-dash')).toThrow()
+      expect(() => validateIdentifierFormat('has space')).toThrow()
+      expect(() => validateIdentifierFormat('has.dot')).toThrow()
+      expect(() => validateIdentifierFormat("has'quote")).toThrow()
+      expect(() => validateIdentifierFormat('')).toThrow()
+    })
+  })
+
+  describe('Whitelist Validation', () => {
+    const allowedColumns = new Set(['id', 'name', 'email', 'status', 'created_at'])
+
+    test('accepts values in whitelist', () => {
+      expect(validateIdentifier('id', allowedColumns)).toBe('id')
+      expect(validateIdentifier('name', allowedColumns)).toBe('name')
+      expect(validateIdentifier('created_at', allowedColumns)).toBe('created_at')
+    })
+
+    test('rejects values not in whitelist', () => {
+      expect(() => validateIdentifier('password', allowedColumns)).toThrow()
+      expect(() => validateIdentifier('unknown', allowedColumns)).toThrow()
+      expect(() => validateIdentifier('ID', allowedColumns)).toThrow() // case sensitive
+    })
+
+    test('trims whitespace before validation', () => {
+      expect(validateIdentifier('  id  ', allowedColumns)).toBe('id')
+      expect(validateIdentifier('\tname\t', allowedColumns)).toBe('name')
+    })
+
+    test('rejects empty values', () => {
+      expect(() => validateIdentifier('', allowedColumns)).toThrow()
+      expect(() => validateIdentifier('   ', allowedColumns)).toThrow()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    const validColumns = new Set(['column'])
+
+    test('handles very long strings', () => {
+      const longAttack = 'a'.repeat(1000) + "'; DROP TABLE"
+      expect(() => validateIdentifier(longAttack, validColumns)).toThrow()
+    })
+
+    test('handles unicode characters', () => {
+      const unicodeAttacks = [
+        'column\u0000',          // Null character
+        'column\u0027',          // Unicode single quote
+        'column\uFF07',          // Fullwidth apostrophe
+        'column\u2019',          // Right single quote
+      ]
+
+      unicodeAttacks.forEach(attack => {
+        expect(() => validateIdentifier(attack, validColumns)).toThrow()
+      })
+    })
+
+    test('handles array/object inputs gracefully', () => {
+      expect(() => validateIdentifier([] as any, validColumns)).toThrow()
+      expect(() => validateIdentifier({} as any, validColumns)).toThrow()
+      expect(() => validateIdentifier(null as any, validColumns)).toThrow()
+      expect(() => validateIdentifier(undefined as any, validColumns)).toThrow()
+    })
+  })
+})

--- a/server/src/routes/queries.ts
+++ b/server/src/routes/queries.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express'
-import { executeQuery, getTablesList } from '../services/queryService.js'
+import { getTablesList } from '../services/queryService.js'
 
 const router = Router()
 
@@ -9,19 +9,6 @@ router.get('/tables', async (_req, res) => {
     return res.json({ success: true, data: tables })
   } catch (error) {
     return res.status(500).json({ success: false, error: 'Failed to fetch tables' })
-  }
-})
-
-router.post('/execute', async (req, res) => {
-  try {
-    const { query } = req.body
-    if (!query) {
-      return res.status(400).json({ success: false, error: 'Query is required' })
-    }
-    const result = await executeQuery(query)
-    return res.json({ success: true, data: result })
-  } catch (error) {
-    return res.status(500).json({ success: false, error: 'Query execution failed' })
   }
 })
 

--- a/server/src/services/__tests__/aggregationService.test.ts
+++ b/server/src/services/__tests__/aggregationService.test.ts
@@ -54,7 +54,7 @@ describe('AggregationService helpers', () => {
       value: ['(Empty)', '(N/A)', 5]
     })
 
-    expect(condition).toBe("(base_table.status IN ('N/A', 5) OR base_table.status = '' OR isNull(base_table.status))")
+    expect(condition).toBe("(base_table.`status` IN ('N/A', 5) OR base_table.`status` = '' OR isNull(base_table.`status`))")
   })
 
   test('buildFilterCondition handles nulls in IN filter', () => {
@@ -64,7 +64,7 @@ describe('AggregationService helpers', () => {
       value: [null, 'value']
     })
 
-    expect(condition).toBe("(base_table.notes IN ('value') OR isNull(base_table.notes))")
+    expect(condition).toBe("(base_table.`notes` IN ('value') OR isNull(base_table.`notes`))")
   })
 
   test('buildFilterCondition handles equality with (Empty)', () => {
@@ -74,7 +74,7 @@ describe('AggregationService helpers', () => {
       value: '(Empty)'
     })
 
-    expect(condition).toBe("(base_table.age_group = '' OR isNull(base_table.age_group))")
+    expect(condition).toBe("(base_table.`age_group` = '' OR isNull(base_table.`age_group`))")
   })
 
   test('buildFilterCondition handles equality with N/A literal', () => {
@@ -84,7 +84,7 @@ describe('AggregationService helpers', () => {
       value: '(N/A)'
     })
 
-    expect(condition).toBe("base_table.age_group = 'N/A'")
+    expect(condition).toBe("base_table.`age_group` = 'N/A'")
   })
 })
 
@@ -161,7 +161,7 @@ describe('AggregationService - Cross-Table Filtering', () => {
       )
 
       expect(subquery).toBe(
-        "base_table.patient_id IN (SELECT patient_id FROM biai.patients_abc123 WHERE radiation_therapy = 'Yes')"
+        "base_table.`patient_id` IN (SELECT `patient_id` FROM biai.patients_abc123 WHERE `radiation_therapy` = 'Yes')"
       )
     })
 
@@ -180,7 +180,7 @@ describe('AggregationService - Cross-Table Filtering', () => {
       )
 
       expect(subquery).toBe(
-        "base_table.patient_id IN (SELECT patient_id FROM biai.samples_abc123 WHERE sample_type = 'Tumor')"
+        "base_table.`patient_id` IN (SELECT `patient_id` FROM biai.samples_abc123 WHERE `sample_type` = 'Tumor')"
       )
     })
 
@@ -262,7 +262,7 @@ describe('AggregationService - Cross-Table Filtering', () => {
       )
 
       expect(subquery).toBe(
-        "base_table.patient_id IN (SELECT patient_id FROM biai.patients_abc123 WHERE radiation_therapy IN ('Yes', 'No'))"
+        "base_table.`patient_id` IN (SELECT `patient_id` FROM biai.patients_abc123 WHERE `radiation_therapy` IN ('Yes', 'No'))"
       )
     })
 
@@ -281,7 +281,7 @@ describe('AggregationService - Cross-Table Filtering', () => {
       )
 
       expect(subquery).toBe(
-        'base_table.patient_id IN (SELECT patient_id FROM biai.patients_abc123 WHERE age BETWEEN 30 AND 50)'
+        'base_table.`patient_id` IN (SELECT `patient_id` FROM biai.patients_abc123 WHERE `age` BETWEEN 30 AND 50)'
       )
     })
 
@@ -300,11 +300,11 @@ describe('AggregationService - Cross-Table Filtering', () => {
       )
 
       // Should use nested IN subqueries (ClickHouse-friendly, no JOINs)
-      expect(subquery).toContain('sample_id IN')
-      expect(subquery).toContain('SELECT sample_id FROM biai.samples_abc123')
-      expect(subquery).toContain('patient_id IN')
-      expect(subquery).toContain('SELECT patient_id FROM biai.patients_abc123')
-      expect(subquery).toContain('age >= 50')
+      expect(subquery).toContain('`sample_id` IN')
+      expect(subquery).toContain('SELECT `sample_id` FROM biai.samples_abc123')
+      expect(subquery).toContain('`patient_id` IN')
+      expect(subquery).toContain('SELECT `patient_id` FROM biai.patients_abc123')
+      expect(subquery).toContain('`age` >= 50')
     })
 
     test('generates nested IN subquery for reverse transitive relationship (patients→samples→mutations)', () => {
@@ -322,11 +322,11 @@ describe('AggregationService - Cross-Table Filtering', () => {
       )
 
       // Should use nested IN subqueries (ClickHouse-friendly, no JOINs)
-      expect(subquery).toContain('patient_id IN')
-      expect(subquery).toContain('SELECT patient_id FROM biai.samples_abc123')
-      expect(subquery).toContain('sample_id IN')
-      expect(subquery).toContain('SELECT sample_id FROM biai.mutations_abc123')
-      expect(subquery).toContain("gene = 'TP53'")
+      expect(subquery).toContain('`patient_id` IN')
+      expect(subquery).toContain('SELECT `patient_id` FROM biai.samples_abc123')
+      expect(subquery).toContain('`sample_id` IN')
+      expect(subquery).toContain('SELECT `sample_id` FROM biai.mutations_abc123')
+      expect(subquery).toContain("`gene` = 'TP53'")
     })
   })
 
@@ -339,7 +339,7 @@ describe('AggregationService - Cross-Table Filtering', () => {
       (tableName?: string) => (tableName === 'patients' ? 'ancestor_patients' : undefined)
     )
 
-    expect(result).toBe("AND (ancestor_patients.radiation_therapy = 'Yes')")
+    expect(result).toBe("AND (ancestor_patients.`radiation_therapy` = 'Yes')")
   })
 
   test('buildWhereClause handles NOT filters via alias resolver', () => {
@@ -351,7 +351,7 @@ describe('AggregationService - Cross-Table Filtering', () => {
       (tableName?: string) => (tableName === 'patients' ? 'ancestor_patients' : undefined)
     )
 
-    expect(result).toBe("AND (NOT (ancestor_patients.radiation_therapy = 'Yes'))")
+    expect(result).toBe("AND (NOT (ancestor_patients.`radiation_therapy` = 'Yes'))")
   })
 
   test('buildWhereClause generates NOT IN subquery for NOT wrapped cross-table filters', () => {
@@ -363,8 +363,8 @@ describe('AggregationService - Cross-Table Filtering', () => {
     )
 
     expect(result).toContain('NOT IN')
-    expect(result).toContain('SELECT patient_id FROM')
-    expect(result).toContain("radiation_therapy = 'Yes'")
+    expect(result).toContain('SELECT `patient_id` FROM')
+    expect(result).toContain("`radiation_therapy` = 'Yes'")
   })
 
   test('buildWhereClause handles NOT with OR combination on cross-table filters', () => {
@@ -386,9 +386,9 @@ describe('AggregationService - Cross-Table Filtering', () => {
     )
 
     expect(result).toContain('NOT IN')
-    expect(result).toContain('SELECT patient_id FROM')
-    expect(result).toContain("radiation_therapy = 'Yes'")
-    expect(result).toContain('age >= 60')
+    expect(result).toContain('SELECT `patient_id` FROM')
+    expect(result).toContain("`radiation_therapy` = 'Yes'")
+    expect(result).toContain('`age` >= 60')
     expect(result).toContain(' OR ')
   })
 
@@ -402,9 +402,9 @@ describe('AggregationService - Cross-Table Filtering', () => {
 
     expect(result).toContain('NOT IN')
     // Should build nested subqueries: mutations.sample_id NOT IN (SELECT sample_id FROM samples WHERE patient_id IN (SELECT patient_id FROM patients WHERE age >= 60))
-    expect(result).toContain('SELECT sample_id FROM')
-    expect(result).toContain('SELECT patient_id FROM')
-    expect(result).toContain('age >= 60')
+    expect(result).toContain('SELECT `sample_id` FROM')
+    expect(result).toContain('SELECT `patient_id` FROM')
+    expect(result).toContain('`age` >= 60')
   })
 
   test('buildWhereClause includes NULL guard for NOT IN cross-table filters', () => {
@@ -420,7 +420,7 @@ describe('AggregationService - Cross-Table Filtering', () => {
     expect(result).toContain('NOT IN')
     expect(result).toContain('IS NULL')
     expect(result).toContain('OR')
-    expect(result).toContain("radiation_therapy = 'Yes'")
+    expect(result).toContain("`radiation_therapy` = 'Yes'")
   })
 
   describe('findRelationshipPath', () => {
@@ -517,9 +517,9 @@ describe('AggregationService - Cross-Table Filtering', () => {
         mockTablesMetadata
       )
 
-      expect(whereClause).toContain("base_table.sample_type = 'Tumor'")
+      expect(whereClause).toContain("base_table.`sample_type` = 'Tumor'")
       expect(whereClause).toContain(
-        "base_table.patient_id IN (SELECT patient_id FROM biai.patients_abc123 WHERE radiation_therapy = 'Yes')"
+        "base_table.`patient_id` IN (SELECT `patient_id` FROM biai.patients_abc123 WHERE `radiation_therapy` = 'Yes')"
       )
       expect(whereClause).toContain('AND')
     })
@@ -542,7 +542,7 @@ describe('AggregationService - Cross-Table Filtering', () => {
       )
 
       expect(whereClause).toBe(
-        "AND (base_table.patient_id IN (SELECT patient_id FROM biai.patients_abc123 WHERE radiation_therapy = 'Yes'))"
+        "AND (base_table.`patient_id` IN (SELECT `patient_id` FROM biai.patients_abc123 WHERE `radiation_therapy` = 'Yes'))"
       )
     })
 
@@ -563,7 +563,7 @@ describe('AggregationService - Cross-Table Filtering', () => {
         mockTablesMetadata
       )
 
-      expect(whereClause).toBe("AND (base_table.sample_type = 'Tumor')")
+      expect(whereClause).toBe("AND (base_table.`sample_type` = 'Tumor')")
     })
 
     test('filters out non-existent columns from local filters', () => {
@@ -590,7 +590,7 @@ describe('AggregationService - Cross-Table Filtering', () => {
       )
 
       // Should only include sample_type, not non_existent_column
-      expect(whereClause).toBe("AND (base_table.sample_type = 'Tumor')")
+      expect(whereClause).toBe("AND (base_table.`sample_type` = 'Tumor')")
       expect(whereClause).not.toContain('non_existent_column')
     })
 
@@ -654,10 +654,10 @@ describe('AggregationService - Cross-Table Filtering', () => {
       )
 
       expect(whereClause).toContain(
-        "base_table.patient_id IN (SELECT patient_id FROM biai.samples_abc123 WHERE sample_type = 'Tumor')"
+        "base_table.`patient_id` IN (SELECT `patient_id` FROM biai.samples_abc123 WHERE `sample_type` = 'Tumor')"
       )
       expect(whereClause).toContain(
-        "base_table.patient_id IN (SELECT patient_id FROM biai.treatments_abc123 WHERE treatment_type = 'Chemotherapy')"
+        "base_table.`patient_id` IN (SELECT `patient_id` FROM biai.treatments_abc123 WHERE `treatment_type` = 'Chemotherapy')"
       )
     })
   })
@@ -688,8 +688,8 @@ describe('AggregationService - Cross-Table Filtering', () => {
         mockTablesMetadata
       )
 
-      expect(whereClause).toContain("base_table.sample_type = 'Tumor'")
-      expect(whereClause).toContain("base_table.sample_type = 'Normal'")
+      expect(whereClause).toContain("base_table.`sample_type` = 'Tumor'")
+      expect(whereClause).toContain("base_table.`sample_type` = 'Normal'")
       expect(whereClause).toContain('OR')
     })
 
@@ -717,9 +717,9 @@ describe('AggregationService - Cross-Table Filtering', () => {
         mockTablesMetadata
       )
 
-      expect(whereClause).toContain("base_table.sample_type = 'Tumor'")
+      expect(whereClause).toContain("base_table.`sample_type` = 'Tumor'")
       expect(whereClause).toContain(
-        "base_table.patient_id IN (SELECT patient_id FROM biai.patients_abc123 WHERE radiation_therapy = 'Yes')"
+        "base_table.`patient_id` IN (SELECT `patient_id` FROM biai.patients_abc123 WHERE `radiation_therapy` = 'Yes')"
       )
     })
   })
@@ -765,10 +765,10 @@ describe('AggregationService - countBy metrics', () => {
         {
           alias: 'ancestor_0',
           table: 'biai.patients_raw',
-          on: 'base_table.patient_id = ancestor_0.patient_id'
+          on: 'base_table.`patient_id` = ancestor_0.`patient_id`'
         }
       ],
-      ancestorExpression: 'ancestor_0.patient_id',
+      ancestorExpression: 'ancestor_0.`patient_id`',
       pathSegments: [
         { from_table: 'samples', via_column: 'patient_id', to_table: 'patients', referenced_column: 'patient_id' }
       ],
@@ -884,20 +884,20 @@ describe('AggregationService - countBy metrics', () => {
       {
         alias: 'ancestor_0',
         table: 'biai.samples_raw',
-        on: 'base_table.sample_id = ancestor_0.sample_id'
+        on: 'base_table.`sample_id` = ancestor_0.`sample_id`'
       },
       {
         alias: 'ancestor_1',
         table: 'biai.patients_raw',
-        on: 'ancestor_0.patient_id = ancestor_1.patient_id'
+        on: 'ancestor_0.`patient_id` = ancestor_1.`patient_id`'
       },
       {
         alias: 'ancestor_2',
         table: 'biai.hospitals_raw',
-        on: 'ancestor_1.hospital_id = ancestor_2.hospital_id'
+        on: 'ancestor_1.`hospital_id` = ancestor_2.`hospital_id`'
       }
     ])
-    expect(context.ancestorExpression).toBe('ancestor_2.hospital_id')
+    expect(context.ancestorExpression).toBe('ancestor_2.`hospital_id`')
     expect(context.parentTable).toBe('hospitals')
     expect(context.parentColumn).toBe('hospital_id')
     expect(context.pathSegments).toEqual([
@@ -1041,10 +1041,10 @@ describe('AggregationService - countBy metrics', () => {
 
     // Should use parent-level exclusion: parent_id NOT IN (SELECT patient_id FROM samples WHERE sample_type = 'Primary')
     expect(result).toContain('NOT IN')
-    expect(result).toContain('SELECT patient_id')
+    expect(result).toContain('SELECT `patient_id`')
     expect(result).toContain('FROM biai.samples_raw')
-    expect(result).toContain("sample_type = 'Primary'")
-    expect(result).toContain('base_table.patient_id')
+    expect(result).toContain("`sample_type` = 'Primary'")
+    expect(result).toContain('base_table.`patient_id`')
   })
 
   test('NOT filter with parent counting excludes parents with ANY matching child', () => {
@@ -1081,8 +1081,8 @@ describe('AggregationService - countBy metrics', () => {
 
     // Should exclude parents where ANY child has sample_type IN ('Primary', 'Recurrent')
     expect(result).toContain('NOT IN')
-    expect(result).toContain('SELECT patient_id')
-    expect(result).toContain("sample_type IN ('Primary'")
+    expect(result).toContain('SELECT `patient_id`')
+    expect(result).toContain("`sample_type` IN ('Primary'")
     expect(result).toContain("'Recurrent')")
   })
 
@@ -1111,7 +1111,7 @@ describe('AggregationService - countBy metrics', () => {
 
     // Should use row-level NOT (no subquery)
     expect(result).toContain('NOT')
-    expect(result).toContain("sample_type = 'Primary'")
+    expect(result).toContain("`sample_type` = 'Primary'")
     expect(result).not.toContain('NOT IN')
     expect(result).not.toContain('SELECT')
   })
@@ -1160,7 +1160,7 @@ describe('AggregationService - countBy metrics', () => {
 
     // Parent-level filters should use regular NOT with alias (not exclusion subquery)
     expect(result).toContain('NOT')
-    expect(result).toContain('ancestor_0.age')
+    expect(result).toContain('ancestor_0.`age`')
     expect(result).not.toContain('NOT IN')
   })
 })

--- a/server/src/services/__tests__/datasetService.test.ts
+++ b/server/src/services/__tests__/datasetService.test.ts
@@ -131,8 +131,8 @@ describe('DatasetService', () => {
     expect(result.display_name).toBe('Clinical Patients')
     expect(result.row_count).toBe(2)
 
-    // CREATE TABLE command issued inside dataset database
-    expect(commandMock.mock.calls[0]?.[0].query).toContain(`CREATE TABLE IF NOT EXISTS ${datasetMeta.database_name}.`)
+    // CREATE TABLE command issued inside dataset database (with escaped identifiers)
+    expect(commandMock.mock.calls[0]?.[0].query).toContain(`CREATE TABLE IF NOT EXISTS \`${datasetMeta.database_name}\`.`)
     // Dataset timestamp update
     expect(commandMock.mock.calls[1]?.[0].query).toContain('ALTER TABLE biai.datasets_metadata UPDATE')
 

--- a/server/src/services/queryService.ts
+++ b/server/src/services/queryService.ts
@@ -1,9 +1,13 @@
 import clickhouseClient from '../config/clickhouse.js'
 
-export const executeQuery = async (query: string) => {
+/**
+ * Get the list of tables in the current ClickHouse database.
+ * This is a safe, predefined query with no user input.
+ */
+export const getTablesList = async () => {
   try {
     const result = await clickhouseClient.query({
-      query,
+      query: 'SHOW TABLES',
       format: 'JSONEachRow',
     })
     return await result.json()
@@ -11,9 +15,4 @@ export const executeQuery = async (query: string) => {
     console.error('Query execution error:', error)
     throw error
   }
-}
-
-export const getTablesList = async () => {
-  const query = 'SHOW TABLES'
-  return executeQuery(query)
 }

--- a/server/src/utils/__tests__/sqlSanitizer.test.ts
+++ b/server/src/utils/__tests__/sqlSanitizer.test.ts
@@ -1,0 +1,288 @@
+import { describe, test, expect } from 'vitest'
+import {
+  validateIdentifier,
+  validateIdentifierFormat,
+  escapeIdentifier,
+  ensurePositiveInteger,
+  sanitizeTableName,
+  qualifyTableName,
+  escapeStringValue
+} from '../sqlSanitizer'
+
+describe('SQL Sanitizer', () => {
+  describe('validateIdentifier', () => {
+    const validColumns = new Set(['id', 'name', 'status', 'patient_id', 'sample_type'])
+
+    test('accepts valid column names in whitelist', () => {
+      expect(validateIdentifier('id', validColumns)).toBe('id')
+      expect(validateIdentifier('patient_id', validColumns)).toBe('patient_id')
+      expect(validateIdentifier('sample_type', validColumns)).toBe('sample_type')
+    })
+
+    test('accepts column names with leading/trailing whitespace', () => {
+      expect(validateIdentifier('  id  ', validColumns)).toBe('id')
+      expect(validateIdentifier('\tname\t', validColumns)).toBe('name')
+    })
+
+    test('rejects column names not in whitelist', () => {
+      expect(() => validateIdentifier('unknown_column', validColumns)).toThrow('Invalid column name')
+      expect(() => validateIdentifier('password', validColumns)).toThrow('Invalid column name')
+    })
+
+    test('rejects SQL injection attempts', () => {
+      const attackVectors = [
+        "'; DROP TABLE users; --",
+        "id; SELECT * FROM passwords",
+        "id UNION SELECT password FROM users",
+        "1 OR 1=1",
+        "id\nUNION SELECT * FROM users",
+        "id`; DROP TABLE users; --",
+        "id'; DELETE FROM users WHERE '1'='1",
+        "id OR 1=1--",
+        "id/**/UNION/**/SELECT/**/password/**/FROM/**/users",
+      ]
+
+      attackVectors.forEach(attack => {
+        expect(() => validateIdentifier(attack, validColumns)).toThrow()
+      })
+    })
+
+    test('rejects empty and null values', () => {
+      expect(() => validateIdentifier('', validColumns)).toThrow('non-empty string')
+      expect(() => validateIdentifier('   ', validColumns)).toThrow('non-empty string')
+      expect(() => validateIdentifier(null as any, validColumns)).toThrow('non-empty string')
+      expect(() => validateIdentifier(undefined as any, validColumns)).toThrow('non-empty string')
+    })
+
+    test('rejects excessively long identifiers', () => {
+      const longName = 'a'.repeat(200)
+      const allowedSet = new Set([longName])
+      expect(() => validateIdentifier(longName, allowedSet)).toThrow('exceeds maximum length')
+    })
+  })
+
+  describe('validateIdentifierFormat', () => {
+    test('accepts valid identifier formats', () => {
+      expect(validateIdentifierFormat('column_name')).toBe('column_name')
+      expect(validateIdentifierFormat('_private')).toBe('_private')
+      expect(validateIdentifierFormat('Column123')).toBe('Column123')
+      expect(validateIdentifierFormat('a')).toBe('a')
+    })
+
+    test('rejects invalid identifier formats', () => {
+      expect(() => validateIdentifierFormat('123start')).toThrow('Invalid column name format')
+      expect(() => validateIdentifierFormat('has-dash')).toThrow('Invalid column name format')
+      expect(() => validateIdentifierFormat('has space')).toThrow('Invalid column name format')
+      expect(() => validateIdentifierFormat('has.dot')).toThrow('Invalid column name format')
+      expect(() => validateIdentifierFormat("has'quote")).toThrow('Invalid column name format')
+    })
+
+    test('rejects SQL injection in format validation', () => {
+      expect(() => validateIdentifierFormat("col; DROP TABLE")).toThrow()
+      expect(() => validateIdentifierFormat("col'--")).toThrow()
+      expect(() => validateIdentifierFormat('col`test')).toThrow()
+    })
+  })
+
+  describe('escapeIdentifier', () => {
+    test('wraps valid identifiers in backticks', () => {
+      expect(escapeIdentifier('column_name')).toBe('`column_name`')
+      expect(escapeIdentifier('_private')).toBe('`_private`')
+      expect(escapeIdentifier('Table123')).toBe('`Table123`')
+    })
+
+    test('rejects invalid identifier formats', () => {
+      expect(() => escapeIdentifier('has space')).toThrow('Invalid identifier format')
+      expect(() => escapeIdentifier('has-dash')).toThrow('Invalid identifier format')
+      expect(() => escapeIdentifier("has'quote")).toThrow('Invalid identifier format')
+    })
+
+    test('rejects empty values', () => {
+      expect(() => escapeIdentifier('')).toThrow('non-empty string')
+      expect(() => escapeIdentifier('   ')).toThrow('non-empty string')
+    })
+
+    test('rejects SQL injection attempts', () => {
+      expect(() => escapeIdentifier("col`; DROP TABLE")).toThrow()
+      expect(() => escapeIdentifier("col'; --")).toThrow()
+    })
+  })
+
+  describe('ensurePositiveInteger', () => {
+    test('accepts valid positive integers', () => {
+      expect(ensurePositiveInteger(0, 'limit')).toBe(0)
+      expect(ensurePositiveInteger(1, 'limit')).toBe(1)
+      expect(ensurePositiveInteger(100, 'limit')).toBe(100)
+      expect(ensurePositiveInteger(1000000, 'offset')).toBe(1000000)
+    })
+
+    test('accepts valid string integers', () => {
+      expect(ensurePositiveInteger('0', 'limit')).toBe(0)
+      expect(ensurePositiveInteger('50', 'limit')).toBe(50)
+      expect(ensurePositiveInteger('  100  ', 'offset')).toBe(100)
+    })
+
+    test('rejects negative integers', () => {
+      expect(() => ensurePositiveInteger(-1, 'limit')).toThrow('non-negative integer')
+      expect(() => ensurePositiveInteger('-5', 'limit')).toThrow('non-negative integer')
+    })
+
+    test('rejects non-integer values', () => {
+      expect(() => ensurePositiveInteger(1.5, 'limit')).toThrow('non-negative integer')
+      expect(() => ensurePositiveInteger('1.5', 'limit')).toThrow('non-negative integer')
+      expect(() => ensurePositiveInteger(Infinity, 'limit')).toThrow('non-negative integer')
+      expect(() => ensurePositiveInteger(NaN, 'limit')).toThrow('non-negative integer')
+    })
+
+    test('rejects SQL injection in LIMIT/OFFSET', () => {
+      const attackVectors = [
+        '1; DROP TABLE users',
+        '1 OR 1=1',
+        '1--',
+        '1/*comment*/',
+        '1e10',
+        '0x10',
+        'null',
+        'undefined',
+      ]
+
+      attackVectors.forEach(attack => {
+        expect(() => ensurePositiveInteger(attack, 'limit')).toThrow()
+      })
+    })
+
+    test('rejects non-numeric types', () => {
+      expect(() => ensurePositiveInteger(null, 'limit')).toThrow()
+      expect(() => ensurePositiveInteger(undefined, 'limit')).toThrow()
+      expect(() => ensurePositiveInteger({}, 'limit')).toThrow()
+      expect(() => ensurePositiveInteger([], 'limit')).toThrow()
+    })
+  })
+
+  describe('sanitizeTableName', () => {
+    test('converts to lowercase and replaces invalid chars', () => {
+      expect(sanitizeTableName('MyTable')).toBe('mytable')
+      expect(sanitizeTableName('My Table')).toBe('my_table')
+      expect(sanitizeTableName('My-Table!')).toBe('my_table_')
+      expect(sanitizeTableName('table@#$name')).toBe('table___name')
+    })
+
+    test('handles names starting with numbers', () => {
+      expect(sanitizeTableName('123table')).toBe('_123table')
+    })
+
+    test('preserves valid names', () => {
+      expect(sanitizeTableName('valid_table_name')).toBe('valid_table_name')
+      expect(sanitizeTableName('_private_table')).toBe('_private_table')
+    })
+
+    test('rejects empty names', () => {
+      expect(() => sanitizeTableName('')).toThrow('non-empty string')
+      expect(() => sanitizeTableName('   ')).toThrow('non-empty string')
+    })
+
+    test('rejects excessively long names', () => {
+      const longName = 'a'.repeat(200)
+      expect(() => sanitizeTableName(longName)).toThrow('exceeds maximum length')
+    })
+  })
+
+  describe('qualifyTableName', () => {
+    test('creates fully qualified name with escaping', () => {
+      expect(qualifyTableName('biai', 'users')).toBe('`biai`.`users`')
+      expect(qualifyTableName('my_database', 'my_table')).toBe('`my_database`.`my_table`')
+    })
+
+    test('rejects invalid database or table names', () => {
+      expect(() => qualifyTableName('invalid db', 'table')).toThrow()
+      expect(() => qualifyTableName('db', 'invalid table')).toThrow()
+    })
+  })
+
+  describe('escapeStringValue', () => {
+    test('escapes single quotes', () => {
+      expect(escapeStringValue("O'Brien")).toBe("O\\'Brien")
+      expect(escapeStringValue("it's")).toBe("it\\'s")
+      expect(escapeStringValue("''")).toBe("\\'\\'")
+    })
+
+    test('escapes backslashes', () => {
+      expect(escapeStringValue('path\\to\\file')).toBe('path\\\\to\\\\file')
+      expect(escapeStringValue('C:\\')).toBe('C:\\\\')
+    })
+
+    test('escapes both backslashes and quotes', () => {
+      expect(escapeStringValue("path\\to\\'file")).toBe("path\\\\to\\\\\\'file")
+    })
+
+    test('handles empty strings', () => {
+      expect(escapeStringValue('')).toBe('')
+    })
+
+    test('handles strings without special characters', () => {
+      expect(escapeStringValue('normal string')).toBe('normal string')
+      expect(escapeStringValue('12345')).toBe('12345')
+    })
+
+    test('rejects non-string values', () => {
+      expect(() => escapeStringValue(123 as any)).toThrow('must be a string')
+      expect(() => escapeStringValue(null as any)).toThrow('must be a string')
+    })
+  })
+
+  describe('SQL Injection Attack Vectors', () => {
+    const validColumns = new Set(['id', 'name', 'email'])
+
+    test('blocks classic SQL injection patterns', () => {
+      const attacks = [
+        "' OR '1'='1",
+        "'; DROP TABLE users; --",
+        "' UNION SELECT * FROM users --",
+        "1; DELETE FROM users",
+        "admin'--",
+        "' OR 1=1 #",
+        "') OR ('1'='1",
+      ]
+
+      attacks.forEach(attack => {
+        expect(() => validateIdentifier(attack, validColumns)).toThrow()
+      })
+    })
+
+    test('blocks comment-based injection', () => {
+      const attacks = [
+        'id/*comment*/',
+        'id--comment',
+        'id#comment',
+      ]
+
+      attacks.forEach(attack => {
+        expect(() => validateIdentifier(attack, validColumns)).toThrow()
+      })
+    })
+
+    test('blocks encoding-based attacks', () => {
+      const attacks = [
+        'id%27',  // URL encoded quote
+        'id\x27', // Hex quote
+        'id\u0027', // Unicode quote
+      ]
+
+      attacks.forEach(attack => {
+        expect(() => validateIdentifier(attack, validColumns)).toThrow()
+      })
+    })
+
+    test('blocks newline/carriage return injection', () => {
+      const attacks = [
+        "id\n UNION SELECT",
+        "id\r\n DROP TABLE",
+        "id\rDELETE FROM",
+      ]
+
+      attacks.forEach(attack => {
+        expect(() => validateIdentifier(attack, validColumns)).toThrow()
+      })
+    })
+  })
+})

--- a/server/src/utils/sqlSanitizer.ts
+++ b/server/src/utils/sqlSanitizer.ts
@@ -1,0 +1,238 @@
+/**
+ * SQL Sanitization Utilities for ClickHouse
+ *
+ * ClickHouse supports parameterized queries for VALUES only ({param:Type} syntax).
+ * Identifiers (column/table names) cannot be parameterized and must be validated
+ * against a whitelist and escaped.
+ *
+ * Security strategy:
+ * 1. VALUES: Use ClickHouse parameterized queries
+ * 2. IDENTIFIERS: Whitelist validation + backtick escaping as defense-in-depth
+ */
+
+// Valid identifier pattern: starts with letter/underscore, followed by alphanumeric/underscore
+const IDENTIFIER_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/
+
+// Maximum identifier length (ClickHouse default)
+const MAX_IDENTIFIER_LENGTH = 128
+
+/**
+ * Validate an identifier against a whitelist of allowed names.
+ * Use this for column names and table names that come from user input.
+ *
+ * @param name - The identifier to validate
+ * @param allowedSet - Set of allowed identifier names (from schema)
+ * @param entityType - Type of entity for error messages
+ * @returns The validated identifier (trimmed)
+ * @throws Error if the identifier is not in the whitelist
+ *
+ * @example
+ * const validColumns = new Set(['id', 'name', 'status'])
+ * const column = validateIdentifier(userInput, validColumns, 'column')
+ */
+export function validateIdentifier(
+  name: string,
+  allowedSet: Set<string>,
+  entityType: 'column' | 'table' | 'database' = 'column'
+): string {
+  if (!name || typeof name !== 'string') {
+    throw new Error(`Invalid ${entityType} name: must be a non-empty string`)
+  }
+
+  const trimmed = name.trim()
+
+  if (trimmed.length === 0) {
+    throw new Error(`Invalid ${entityType} name: must be a non-empty string`)
+  }
+
+  if (trimmed.length > MAX_IDENTIFIER_LENGTH) {
+    throw new Error(`Invalid ${entityType} name: exceeds maximum length of ${MAX_IDENTIFIER_LENGTH}`)
+  }
+
+  if (!allowedSet.has(trimmed)) {
+    throw new Error(`Invalid ${entityType} name: '${trimmed}' is not a valid ${entityType}`)
+  }
+
+  return trimmed
+}
+
+/**
+ * Validate that an identifier matches the expected format pattern.
+ * Use this for identifiers that come from trusted sources (like database schema)
+ * but need format verification as defense-in-depth.
+ *
+ * @param name - The identifier to validate
+ * @param entityType - Type of entity for error messages
+ * @returns The validated identifier
+ * @throws Error if the identifier doesn't match the expected format
+ */
+export function validateIdentifierFormat(
+  name: string,
+  entityType: 'column' | 'table' | 'database' = 'column'
+): string {
+  if (!name || typeof name !== 'string') {
+    throw new Error(`Invalid ${entityType} name: must be a non-empty string`)
+  }
+
+  const trimmed = name.trim()
+
+  if (trimmed.length === 0) {
+    throw new Error(`Invalid ${entityType} name: must be a non-empty string`)
+  }
+
+  if (trimmed.length > MAX_IDENTIFIER_LENGTH) {
+    throw new Error(`Invalid ${entityType} name: exceeds maximum length of ${MAX_IDENTIFIER_LENGTH}`)
+  }
+
+  if (!IDENTIFIER_REGEX.test(trimmed)) {
+    throw new Error(`Invalid ${entityType} name format: '${trimmed}'`)
+  }
+
+  return trimmed
+}
+
+/**
+ * Escape an identifier for safe use in SQL using ClickHouse backtick quoting.
+ * Always use after whitelist validation - this is a secondary defense layer.
+ *
+ * @param name - The identifier to escape (must already be validated)
+ * @returns The escaped identifier wrapped in backticks
+ * @throws Error if the identifier format is invalid
+ *
+ * @example
+ * const escaped = escapeIdentifier('column_name') // Returns: `column_name`
+ */
+export function escapeIdentifier(name: string): string {
+  if (!name || typeof name !== 'string') {
+    throw new Error('Invalid identifier: must be a non-empty string')
+  }
+
+  const trimmed = name.trim()
+
+  if (trimmed.length === 0) {
+    throw new Error('Invalid identifier: must be a non-empty string')
+  }
+
+  // Validate format before escaping (defense in depth)
+  if (!IDENTIFIER_REGEX.test(trimmed)) {
+    throw new Error(`Invalid identifier format: '${trimmed}'`)
+  }
+
+  // ClickHouse uses backticks for identifier quoting
+  // Escape any backticks within the name (should not exist if format validated)
+  return `\`${trimmed.replace(/`/g, '``')}\``
+}
+
+/**
+ * Validate and return a non-negative integer for use in LIMIT/OFFSET clauses.
+ *
+ * @param value - The value to validate (number or string)
+ * @param paramName - Name of the parameter for error messages
+ * @returns The validated non-negative integer
+ * @throws Error if the value is not a valid non-negative integer
+ *
+ * @example
+ * const limit = ensurePositiveInteger(req.query.limit, 'limit')
+ */
+export function ensurePositiveInteger(value: unknown, paramName: string): number {
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value < 0 || !Number.isFinite(value)) {
+      throw new Error(`Invalid ${paramName}: must be a non-negative integer`)
+    }
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    // Strict parsing: only accept digits
+    if (!/^\d+$/.test(trimmed)) {
+      throw new Error(`Invalid ${paramName}: must be a non-negative integer`)
+    }
+    const parsed = parseInt(trimmed, 10)
+    if (isNaN(parsed) || parsed < 0) {
+      throw new Error(`Invalid ${paramName}: must be a non-negative integer`)
+    }
+    return parsed
+  }
+
+  throw new Error(`Invalid ${paramName}: must be a non-negative integer`)
+}
+
+/**
+ * Sanitize a table name to follow ClickHouse naming conventions.
+ * Converts to lowercase and replaces invalid characters with underscores.
+ *
+ * @param name - The table name to sanitize
+ * @returns The sanitized table name
+ * @throws Error if the name cannot be sanitized to a valid identifier
+ *
+ * @example
+ * const tableName = sanitizeTableName('My Table!') // Returns: 'my_table_'
+ */
+export function sanitizeTableName(name: string): string {
+  if (!name || typeof name !== 'string') {
+    throw new Error('Invalid table name: must be a non-empty string')
+  }
+
+  const trimmed = name.trim()
+
+  if (trimmed.length === 0) {
+    throw new Error('Invalid table name: must be a non-empty string')
+  }
+
+  // Convert to lowercase and replace invalid characters
+  let sanitized = trimmed.toLowerCase().replace(/[^a-z0-9_]/g, '_')
+
+  // Ensure it starts with a letter or underscore
+  if (/^[0-9]/.test(sanitized)) {
+    sanitized = '_' + sanitized
+  }
+
+  // Final validation
+  if (!IDENTIFIER_REGEX.test(sanitized)) {
+    throw new Error(`Invalid table name: '${name}' cannot be sanitized to a valid identifier`)
+  }
+
+  if (sanitized.length > MAX_IDENTIFIER_LENGTH) {
+    throw new Error(`Invalid table name: exceeds maximum length of ${MAX_IDENTIFIER_LENGTH}`)
+  }
+
+  return sanitized
+}
+
+/**
+ * Build a fully qualified table name from database and table parts.
+ * Both parts are escaped for safe SQL use.
+ *
+ * @param database - The database name (must be validated)
+ * @param table - The table name (must be validated)
+ * @returns The fully qualified table name: `database`.`table`
+ *
+ * @example
+ * const fqn = qualifyTableName('biai', 'users') // Returns: `biai`.`users`
+ */
+export function qualifyTableName(database: string, table: string): string {
+  return `${escapeIdentifier(database)}.${escapeIdentifier(table)}`
+}
+
+/**
+ * Escape a string value for safe use in SQL.
+ * Use ClickHouse parameterized queries ({param:String}) when possible instead.
+ * This is a fallback for complex dynamic SQL where parameterization is not feasible.
+ *
+ * @param value - The string value to escape
+ * @returns The escaped string (without surrounding quotes)
+ *
+ * @example
+ * const escaped = escapeStringValue("O'Brien") // Returns: O\'Brien
+ */
+export function escapeStringValue(value: string): string {
+  if (typeof value !== 'string') {
+    throw new Error('Value must be a string')
+  }
+
+  // ClickHouse string escaping: escape backslashes first, then single quotes
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+}


### PR DESCRIPTION
## Summary
Fixes #88 - SQL injection vulnerability in aggregationService and related services.

**Key changes:**
- Created centralized `sqlSanitizer.ts` utility with functions for identifier validation and escaping
- Removed dangerous `/api/queries/execute` endpoint that accepted raw SQL
- Applied identifier escaping across all services: aggregationService, datasetService, columnAnalyzer, databases route
- Added 66 comprehensive security tests covering SQL injection attack vectors

**Security approach:**
- **Whitelist validation**: Column/table names validated against schema
- **Identifier escaping**: All identifiers wrapped in backticks (ClickHouse syntax)
- **Defense-in-depth**: Multiple layers of protection

**ClickHouse limitation**: ClickHouse only supports parameterized queries for VALUES (`{param:Type}`), NOT for identifiers. This fix uses backtick escaping as the primary defense for identifiers.

## Test plan
- [x] All 234 server tests pass (including 66 new security tests)
- [x] All 73 client tests pass
- [x] Security tests verify classic SQL injection, ClickHouse-specific attacks, comment injection, encoding attacks, and LIMIT injection are all blocked
- [ ] Manual testing: Upload CSV with special characters in column names
- [ ] Manual testing: Apply filters with SQL injection attempts in values

🤖 Generated with [Claude Code](https://claude.com/claude-code)