### PR TITLE
Fix: Allow merging multiple spreadsheet sheets into the same new table

### DIFF
--- a/server/src/routes/__tests__/spreadsheet.test.ts
+++ b/server/src/routes/__tests__/spreadsheet.test.ts
@@ -184,5 +184,84 @@ describe('Spreadsheet API Routes', () => {
         'existing_table_2'
       )
     })
+
+    test('should merge multiple sheets into the same new table', async () => {
+      // Mock parsing for two sheets
+      mockParseSpreadsheetSheet
+        .mockResolvedValueOnce({
+          columns: [{ name: 'A', type: 'String', nullable: true, index: 0 }],
+          rows: [['val1']],
+          rowCount: 1
+        } as any)
+        .mockResolvedValueOnce({
+          columns: [{ name: 'A', type: 'String', nullable: true, index: 0 }],
+          rows: [['val2']],
+          rowCount: 1
+        } as any)
+
+      // Mock addTableToDataset response
+      mockAddTableToDataset.mockResolvedValue({
+        table_id: 'merged_table',
+        table_name: 'merged_table',
+        display_name: 'Merged Table',
+        row_count: 1
+      } as any)
+
+      const sheetsConfig = [
+        { 
+          sheetName: 'Sheet1', 
+          tableName: 'merged_table', 
+          displayName: 'Merged Table',
+          importMode: 'append', // First sheet creates
+          targetTableId: undefined 
+        },
+        { 
+          sheetName: 'Sheet2', 
+          tableName: 'merged_table', 
+          displayName: 'Merged Table',
+          importMode: 'append', // Second sheet should append
+          targetTableId: undefined // Intention is to target the same new table
+        }
+      ]
+
+      const response = await request(app)
+        .post('/api/datasets/test-ds/spreadsheets/import')
+        .send({
+          sheetsConfig: JSON.stringify(sheetsConfig)
+        })
+
+      expect(response.status).toBe(200)
+      expect(response.body.success).toBe(true)
+      
+      // Verify first sheet call
+      expect(mockAddTableToDataset).toHaveBeenNthCalledWith(1,
+        'test-ds',
+        'merged_table',
+        'Merged Table',
+        expect.any(String),
+        expect.any(String),
+        expect.anything(),
+        undefined,
+        {},
+        [],
+        'append',
+        undefined 
+      )
+
+      // Verify second sheet call - should append to the table created by Sheet1
+      expect(mockAddTableToDataset).toHaveBeenNthCalledWith(2,
+        'test-ds',
+        'merged_table', 
+        'Merged Table',
+        expect.any(String),
+        expect.any(String),
+        expect.anything(),
+        undefined,
+        {},
+        [],
+        'append',
+        'merged_table' // Verify it uses the ID from the created table
+      )
+    })
   })
 })

--- a/server/src/routes/datasets.ts
+++ b/server/src/routes/datasets.ts
@@ -390,9 +390,16 @@ router.post('/:id/spreadsheets/import', upload.single('file'), async (req, res) 
     }
 
     const importedTables = []
+    const createdTables = new Map<string, string>() // Map<tableName, tableId>
 
     for (const sheetConfig of sheetsConfig) {
-      const { sheetName, tableName, displayName, skipRows = 0, primaryKey, relationships = [], importMode, targetTableId } = sheetConfig
+      let { sheetName, tableName, displayName, skipRows = 0, primaryKey, relationships = [], importMode, targetTableId } = sheetConfig
+
+      // Check if this table was already created in this request
+      if (!targetTableId && createdTables.has(tableName)) {
+        targetTableId = createdTables.get(tableName)
+        importMode = 'append' // Force append for subsequent sheets merging into the same table
+      }
 
       // Parse sheet data
       const parsedData = await parseSpreadsheetSheet(
@@ -420,6 +427,10 @@ router.post('/:id/spreadsheets/import', upload.single('file'), async (req, res) 
         importMode,
         targetTableId
       )
+
+      if (!targetTableId) {
+        createdTables.set(tableName, table.table_id)
+      }
 
       importedTables.push({
         id: table.table_id,


### PR DESCRIPTION
## Description

This PR fixes issue #114 where importing multiple sheets from a spreadsheet into the same new table was not possible. Previously, each sheet would try to create a new table, leading to conflicts or separate tables.

Now, the import logic tracks tables created during the request. If a subsequent sheet targets a table name that was just created, it automatically switches to `append` mode and targets the newly created table ID.

## Changes

- Modified `server/src/routes/datasets.ts`:
    - Added a `createdTables` Map to track `tableName -> tableId`.
    - Logic to check if `tableName` exists in `createdTables` and update `targetTableId`/`importMode` accordingly.
- Updated `server/src/routes/__tests__/spreadsheet.test.ts`:
    - Added a test case verifying that two sheets targeting the same new table result in one creation and one append to the correct ID.

## Verification

- Ran `npm test src/routes/__tests__/spreadsheet.test.ts` (All passed)

Closes #114