### PR TITLE
test(e2e): Add advanced filters, navigation, and delete table tests

### DIFF
--- a/tests/e2e/advanced-filters.spec.ts
+++ b/tests/e2e/advanced-filters.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect, waitForServer, apiCreateDataset, apiUploadCSV, apiDeleteDataset } from './fixtures'
+
+test.describe('Advanced Filters', () => {
+  let datasetId: string
+
+  test.beforeAll(async () => {
+    await waitForServer()
+    const ds = await apiCreateDataset(
+      `E2E Filters ${Date.now()}`,
+      'Dataset for advanced filter e2e tests'
+    )
+    datasetId = ds.datasetId
+    await apiUploadCSV(datasetId, 'example_data/test-data-geographic.csv', 'geographic', 'Geographic Data')
+  })
+
+  test.afterAll(async () => {
+    if (datasetId) {
+      await apiDeleteDataset(datasetId).catch(() => {})
+    }
+  })
+
+  test('numeric range filter with custom min/max', async ({ page }) => {
+    test.setTimeout(60_000)
+    await page.goto(`/datasets/${datasetId}`)
+    await page.waitForLoadState('networkidle')
+
+    // Switch to table tab
+    await page.getByRole('button', { name: /Geographic Data/ }).click()
+
+    // Wait for charts to render
+    const charts = page.locator('.js-plotly-plot')
+    await expect(charts.first()).toBeVisible({ timeout: 15_000 })
+
+    // Find the "age" chart card by its heading, then open filter menu
+    const ageCard = page.locator('div').filter({
+      has: page.locator('h4').filter({ hasText: /^age$/ })
+    }).filter({
+      has: page.locator('.js-plotly-plot')
+    }).last()
+    await expect(ageCard).toBeVisible()
+
+    // Click filter button (⚲)
+    await ageCard.getByTitle('Filter values').click()
+
+    // Numeric filter menu should appear with From/To inputs
+    const fromInput = page.getByLabel('From')
+    const toInput = page.getByLabel('To')
+    await expect(fromInput).toBeVisible()
+    await expect(toInput).toBeVisible()
+
+    // Enter custom range
+    await fromInput.fill('40')
+    await toInput.fill('60')
+
+    // Click Apply
+    await page.getByRole('button', { name: 'Apply' }).click()
+
+    // Verify filter is active
+    await expect(page.getByText('Active Filters:')).toBeVisible({ timeout: 5_000 })
+
+    // Verify row count shows filtered state
+    await expect(page.getByTestId('filtered-count-geographic')).toBeVisible()
+  })
+
+  test('NOT filter toggle on categorical filter', async ({ page }) => {
+    test.setTimeout(60_000)
+    await page.goto(`/datasets/${datasetId}`)
+    await page.waitForLoadState('networkidle')
+
+    // Switch to table tab
+    await page.getByRole('button', { name: /Geographic Data/ }).click()
+
+    // Wait for charts
+    const charts = page.locator('.js-plotly-plot')
+    await expect(charts.first()).toBeVisible({ timeout: 15_000 })
+
+    // Click a bar on a categorical chart to apply filter
+    const firstChart = charts.first()
+    const svgBars = firstChart.locator('g.trace.bars g.points path, g.trace.bars g.point path')
+    if ((await svgBars.count()) > 0) {
+      await svgBars.first().click({ force: true })
+    } else {
+      await firstChart.click({ position: { x: 100, y: 100 } })
+    }
+
+    // Verify filter appears
+    await expect(page.getByText('Active Filters:')).toBeVisible({ timeout: 5_000 })
+
+    // Click the NOT toggle (¬) on the filter chip
+    await page.getByTitle('Add NOT').first().click()
+
+    // Verify NOT badge appears on the chip
+    await expect(page.locator('span').filter({ hasText: /^NOT$/ })).toBeVisible()
+
+    // Click NOT toggle again to remove it
+    await page.getByTitle('Remove NOT').first().click()
+
+    // Verify NOT badge is gone
+    await expect(page.locator('span').filter({ hasText: /^NOT$/ })).not.toBeVisible()
+  })
+
+  test('remove individual filter via chip close button', async ({ page }) => {
+    test.setTimeout(60_000)
+    await page.goto(`/datasets/${datasetId}`)
+    await page.waitForLoadState('networkidle')
+
+    // Switch to table tab
+    await page.getByRole('button', { name: /Geographic Data/ }).click()
+
+    // Wait for charts
+    const charts = page.locator('.js-plotly-plot')
+    await expect(charts.first()).toBeVisible({ timeout: 15_000 })
+
+    // Apply a categorical filter by clicking a chart bar
+    const firstChart = charts.first()
+    const svgBars = firstChart.locator('g.trace.bars g.points path, g.trace.bars g.point path')
+    if ((await svgBars.count()) > 0) {
+      await svgBars.first().click({ force: true })
+    } else {
+      await firstChart.click({ position: { x: 100, y: 100 } })
+    }
+
+    // Verify filter appears
+    await expect(page.getByText('Active Filters:')).toBeVisible({ timeout: 5_000 })
+
+    // Find the × button on the filter chip and click it
+    // The chip has a button with × text for removing the filter
+    const removeBtn = page.locator('button').filter({ hasText: '×' }).first()
+    await removeBtn.click()
+
+    // Verify filters cleared
+    await expect(page.getByText('Active Filters:')).not.toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, waitForServer, apiCreateDataset, apiDeleteDataset } from './fixtures'
+
+test.describe('Navigation & Routing', () => {
+  test.beforeAll(async () => {
+    await waitForServer()
+  })
+
+  test('home page shows dataset list', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // Should show the datasets page with create button
+    await expect(page.getByRole('button', { name: '+ Create Dataset' })).toBeVisible()
+
+    // Navbar should be visible
+    await expect(page.getByText('BIAI').first()).toBeVisible()
+    await expect(page.getByText('Datasets').first()).toBeVisible()
+  })
+
+  test('invalid dataset ID shows error', async ({ page }) => {
+    await page.goto('/datasets/nonexistent-id-12345')
+    await page.waitForLoadState('networkidle')
+
+    // Explorer shows an error for non-existent dataset
+    await expect(page.getByText(/Error.*404|Dataset not found/)).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('invalid manage page shows not found', async ({ page }) => {
+    await page.goto('/datasets/nonexistent-id-12345/manage')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByText('Dataset not found')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('navigate from dataset list to explorer and back', async ({ page }) => {
+    const ds = await apiCreateDataset(`E2E Nav ${Date.now()}`)
+
+    try {
+      await page.goto('/')
+      await page.waitForLoadState('networkidle')
+
+      // Find the dataset and click Explore Data
+      const exploreBtn = page.getByText('Explore Data').first()
+      await expect(exploreBtn).toBeVisible({ timeout: 10_000 })
+      await exploreBtn.click()
+
+      // Should navigate to explorer page
+      await page.waitForURL(/\/datasets\//)
+      await expect(page.getByRole('button', { name: 'Dashboard', exact: true })).toBeVisible({ timeout: 15_000 })
+
+      // Navigate back via navbar "Datasets" link
+      await page.getByRole('link', { name: 'Datasets' }).click()
+      await page.waitForURL(/\/$|\/datasets$/)
+      await expect(page.getByRole('button', { name: '+ Create Dataset' })).toBeVisible()
+    } finally {
+      await apiDeleteDataset(ds.datasetId).catch(() => {})
+    }
+  })
+})

--- a/tests/e2e/table-management.spec.ts
+++ b/tests/e2e/table-management.spec.ts
@@ -186,4 +186,38 @@ test.describe('Table Management', () => {
     // Verify on card
     await expect(treatmentsCard.getByText('patient_id → Patients.patient_id')).toBeVisible()
   })
+
+  test('delete table', async ({ page }) => {
+    await page.goto(`/datasets/${datasetId}/manage`)
+    await page.waitForLoadState('domcontentloaded')
+
+    // Verify all three tables are present
+    await expect(page.getByTestId('table-card-geographic')).toBeVisible()
+    await expect(page.getByTestId('table-card-patients')).toBeVisible()
+    await expect(page.getByTestId('table-card-treatments')).toBeVisible()
+
+    // Handle confirmation dialog
+    page.on('dialog', dialog => dialog.accept())
+
+    // Delete the treatments table
+    const treatmentsCard = page.getByTestId('table-card-treatments')
+    const deletePromise = page.waitForResponse(resp =>
+      resp.url().includes('/tables/') && resp.request().method() === 'DELETE' && resp.status() === 200
+    )
+    await treatmentsCard.getByRole('button', { name: 'Delete' }).click()
+    await deletePromise
+
+    // Verify treatments table is gone
+    await expect(page.getByTestId('table-card-treatments')).not.toBeVisible()
+
+    // Verify other tables still present
+    await expect(page.getByTestId('table-card-geographic')).toBeVisible()
+    await expect(page.getByTestId('table-card-patients')).toBeVisible()
+
+    // Verify persistence after reload
+    await page.reload()
+    await expect(page.getByTestId('table-card-geographic')).toBeVisible()
+    await expect(page.getByTestId('table-card-patients')).toBeVisible()
+    await expect(page.getByTestId('table-card-treatments')).not.toBeVisible()
+  })
 })


### PR DESCRIPTION
## Summary
- Add **advanced-filters.spec.ts**: numeric range filter (custom min/max), NOT filter toggle, remove individual filter chip (3 tests)
- Add **navigation.spec.ts**: home page loads, invalid dataset 404, invalid manage 404, navigate list-to-explorer-and-back (4 tests)
- Add **delete table** test to table-management.spec.ts (1 test)

Total e2e tests: **26** (up from 18)

## Gaps addressed from #146
- [x] Filter type variations — numeric range filters, NOT filter toggle
- [x] Delete table — `DELETE /datasets/:id/tables/:tableId` endpoint now exercised
- [x] Page navigation & routing — home page, 404 handling, navbar navigation

## Test plan
- [x] All 26 e2e tests pass locally (~50s)
- [x] All 105 client unit tests pass
- [x] All 313 server unit tests pass
- [ ] CI passes

Closes part of #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)