### PR TITLE
refactor(DatasetExplorer): extract hooks and utilities (#123)

### DIFF
--- a/CORE.md
+++ b/CORE.md
@@ -101,7 +101,7 @@ npm run build
 ### React Components
 - Functional components with hooks
 - State managed via useState/useEffect
-- Large files need refactoring (DatasetExplorer.tsx is too big)
+- DatasetExplorer decomposed into hooks + components (see architecture below)
 
 ### API Routes
 - RESTful patterns: `/api/datasets`, `/api/datasets/:id/tables`
@@ -124,6 +124,38 @@ npm run build
   - Requires ClickHouse running (`docker-compose up -d clickhouse`)
   - Test data: uses `example_data/` files
   - Fixtures in `tests/e2e/fixtures.ts` provide API helpers for fast dataset setup/teardown
+
+## DatasetExplorer Architecture
+
+The main exploration page (`client/src/pages/DatasetExplorer/`) is decomposed into:
+
+```
+DatasetExplorer/
+├── DatasetExplorer.tsx     # Orchestrator (~620 lines): hook calls, bridge functions, JSX
+├── types.ts                # Shared types, constants, persistence helpers
+├── utils.ts                # Pure utility functions (histogram binning, serialization, etc.)
+├── hooks/
+│   ├── useFilterState.ts   # Filter state: toggleFilter, ranges, URL restore
+│   ├── useCountBy.ts       # Count-by selections, chart overrides, persistence
+│   ├── useDatasetLoader.ts # Data loading, caching, aggregations, survival curves
+│   ├── useFilterPresets.ts # Saved filter presets (localStorage)
+│   ├── useViewPreferences.ts # Chart display preferences
+│   └── useDashboard.ts     # Dashboard chart management
+└── components/
+    ├── ChartContext.tsx     # React context (~30 props shared with all chart components)
+    ├── DatasetHeader.tsx    # Page header
+    ├── TabBar.tsx           # Table tab navigation
+    ├── DashboardView.tsx    # Dashboard grid layout
+    ├── TableSection.tsx     # Per-table chart grid
+    ├── CountIndicator.tsx   # Count-by indicator button + dropdown
+    ├── ActiveFilters.tsx    # Active filter chips bar
+    ├── FilterChip.tsx       # Individual filter chip
+    ├── renderChartByType.tsx# Chart type dispatcher
+    ├── PieChart.tsx, BarChart.tsx, HistogramChart.tsx, etc.
+    └── ...
+```
+
+**Hook dependency flow:** `useCountBy` → `useDatasetLoader` → `useFilterState` (called in order; DatasetExplorer bridges cross-hook dependencies via callbacks).
 
 ## Common Patterns
 
@@ -173,14 +205,14 @@ export const fetchSomething = async (id: string) => {
 | `server/src/services/dashboardService.ts` | Dashboard persistence | Save/load/delete dashboards |
 | `server/src/services/spreadsheetParser.ts` | Excel/ODS import | Multi-sheet support |
 | `server/src/utils/sqlSanitizer.ts` | SQL injection prevention | Column/table name validation |
-| `client/src/pages/DatasetExplorer.tsx` | Main exploration UI | 6K+ lines, needs refactoring (#92) |
+| `client/src/pages/DatasetExplorer/DatasetExplorer.tsx` | Main exploration UI | ~620 lines, orchestrates hooks + components |
 | `client/src/pages/DatasetManage.tsx` | Upload/config UI | Dataset and table management |
 | `client/src/utils/filterHelpers.ts` | Filter logic | Relationship pathfinding, propagation |
 | `clickhouse/init/01-init.sql` | Database schema | 4 metadata tables |
 
 ## Known Issues & Technical Debt
 
-1. **Large Component** (#92) - `DatasetExplorer.tsx` is 6K+ lines; refactoring planned (#119-#123)
+1. ~~**Large Component** (#92) - `DatasetExplorer.tsx` was 6K+ lines~~ (resolved: refactored to ~620 lines via #119-#123)
 2. **Type Duplication** (#94) - Same types defined in client and server
 3. ~~**Missing E2E Tests** (#95) - No end-to-end tests for critical workflows~~ (resolved: Playwright e2e tests added)
 4. **No OpenAPI Docs** (#93) - API endpoints lack formal specification

--- a/client/src/pages/DatasetExplorer/DatasetExplorer.tsx
+++ b/client/src/pages/DatasetExplorer/DatasetExplorer.tsx
@@ -1,25 +1,12 @@
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
-import api from '../../services/api'
-import type { MetricPathSegment } from '../../types'
-import {
-  findRelationshipPath,
-  type Filter,
-  ROW_COUNT_KEY,
-  unwrapNot,
-  rangeKey,
-  rangesEqual,
-  getFilterCountKey,
-  filterContainsColumn,
-  migrateFiltersToCurrentSchema,
-} from '../../utils/filterHelpers'
-import { encodeState, decodeState } from '../../utils/urlHelpers'
-import {
-  type CountBySelection
-} from '../../utils/presetHelpers'
+import { ROW_COUNT_KEY, rangeKey } from '../../utils/filterHelpers'
 import { useFilterPresets } from './hooks/useFilterPresets'
 import { useViewPreferences } from './hooks/useViewPreferences'
 import { useDashboard } from './hooks/useDashboard'
+import { useFilterState } from './hooks/useFilterState'
+import { useCountBy } from './hooks/useCountBy'
+import { useDatasetLoader } from './hooks/useDatasetLoader'
 import { ChartProvider } from './components/ChartContext'
 import { ActiveFilters } from './components/ActiveFilters'
 import { ChartSettingsMenu } from './components/ChartSettingsMenu'
@@ -30,86 +17,37 @@ import { DatasetHeader } from './components/DatasetHeader'
 import { TabBar } from './components/TabBar'
 import { DashboardView } from './components/DashboardView'
 import { TableSection } from './components/TableSection'
+import { CountIndicator } from './components/CountIndicator'
+import { DASHBOARD_SCOPE_KEY } from './types'
 import {
-  DASHBOARD_SCOPE_KEY,
-  CACHE_TTL_MS,
-  CACHE_MAX_ENTRIES_PER_TABLE,
-  MAX_ANCESTOR_DEPTH,
-  persistChartOverrides,
-  loadChartOverrides,
-  type ColumnMetadata,
-  type NumericStats,
-  type HistogramBin,
-  type SurvivalCurvePoint,
-  type ColumnAggregation,
-  type Table,
-  type Dataset,
-  type AncestorOption,
-  type AggregationCacheEntry,
-  type SurvivalCacheEntry,
-} from './types'
+  targetFromCacheKey,
+  normalizeFilterValue,
+  formatRangeValue,
+  metricsMatch,
+  serializeFilters,
+  serializeCountBySelections,
+  normalizeCountBySelections,
+  getDisplayHistogram,
+} from './utils'
 
 function DatasetExplorer() {
   const { id, database } = useParams()
   const navigate = useNavigate()
   const location = useLocation()
 
-  // Determine if we're in database mode or dataset mode
   const isDatabaseMode = !!database
   const identifier = database || id
-  const [dataset, setDataset] = useState<Dataset | null>(null)
 
-  // Helper to determine if we should use database API
-  // Use database API if:
-  // 1. We're in database mode (viewing from /databases/:database), OR
-  // 2. The dataset is a "connected" type (registered existing database)
-  const usesDatabaseAPI = isDatabaseMode ? true : dataset?.database_type === 'connected'
-  const databaseIdentifier = isDatabaseMode ? identifier : dataset?.database_name
-  const datasetIdentifier = dataset?.id
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [columnMetadata, setColumnMetadata] = useState<Record<string, ColumnMetadata[]>>({})
-  const [aggregations, setAggregations] = useState<Record<string, Record<string, AggregationCacheEntry>>>({})
-  const [survivalCurves, setSurvivalCurves] = useState<Record<string, Record<string, SurvivalCacheEntry>>>({})
-  const [baselineAggregations, setBaselineAggregations] = useState<Record<string, ColumnAggregation[]>>({})
-  const [filters, setFilters] = useState<Filter[]>([])
-  const [activeFilterMenu, setActiveFilterMenu] = useState<{ tableName: string; columnName: string; countKey?: string } | null>(null)
-  const [customRangeInputs, setCustomRangeInputs] = useState<Record<string, { min: string; max: string }>>({})
-  const [rangeSelections, setRangeSelections] = useState<Record<string, Array<{ start: number; end: number }>>>({})
-  const [countBySelections, setCountBySelections] = useState<Record<string, CountBySelection>>({})
-  const [countByReady, setCountByReady] = useState(false)
-
-  // Filter preset management (extracted hook)
-  const {
-    presets,
-    showSavePresetDialog, setShowSavePresetDialog,
-    showManagePresetsDialog, setShowManagePresetsDialog,
-    showPresetsDropdown, setShowPresetsDropdown,
-    presetNameInput, setPresetNameInput,
-    editingPresetId, setEditingPresetId,
-    savePreset, applyPreset, deletePreset, renamePreset,
-    exportPresets, importPresets,
-  } = useFilterPresets({
-    identifier,
-    filters,
-    countBySelections,
-    setFilters,
-    setCountBySelections,
-  })
-
-  // View preferences (extracted hook)
-  const {
-    showPercentageLabels, setShowPercentageLabels,
-    showSettingsMenu, setShowSettingsMenu,
-    settingsButtonRef, settingsMenuRef,
-    getViewPreference, toggleViewPreference,
-    getSurvivalViewPreference, toggleSurvivalViewPreference,
-  } = useViewPreferences({ identifier })
-
-  // Tab navigation state: track which table tab is currently active
+  // Tab navigation state
   const [activeTab, setActiveTab] = useState<string | null>(null)
+  const isUpdatingURL = useRef(false)
 
-  // Dashboard management (extracted hook)
+  // ── Extracted hooks ───────────────────────────────────────────────
+
+  const filterState = useFilterState({ identifier })
+
+  const countBy = useCountBy({ identifier })
+
   const {
     dashboardCharts, setDashboardCharts,
     visibleDashboardKeys,
@@ -125,105 +63,170 @@ function DatasetExplorer() {
     saveDashboard, loadDashboard, deleteDashboard, renameDashboard,
   } = useDashboard({ identifier })
 
-  const [chartCountOverrides, setChartCountOverrides] = useState<Record<string, string>>({})
-  const [activeCountMenuKey, setActiveCountMenuKey] = useState<string | null>(null)
-  const [ancestorOptions, setAncestorOptions] = useState<Record<string, AncestorOption[]>>({})
-  const survivalRequests = useRef<Set<string>>(new Set())
+  const loader = useDatasetLoader({
+    id,
+    database,
+    identifier,
+    isDatabaseMode,
+    filters: filterState.filters,
+    currentFiltersKey: filterState.currentFiltersKey,
+    countBySelections: countBy.countBySelections,
+    countByReady: countBy.countByReady,
+    getCountByCacheKey: countBy.getCountByCacheKey,
+    chartCountOverrides: countBy.chartCountOverrides,
+    dashboardCharts,
+    getDashboardChartKey,
+    visibleDashboardKeys,
+    previousCountByRef: countBy.previousCountByRef,
+    onDatasetLoaded: () => {
+      filterState.setCustomRangeInputs({})
+      filterState.setRangeSelections({})
+      filterState.setActiveFilterMenu(null)
+      setActiveTab('dashboard')
+    },
+    onAncestorOptionsChanged: (options) => {
+      countBy.setCountBySelections(prev => normalizeCountBySelections(prev, options))
+    },
+  })
 
-  // Track if filters have been initialized from URL to prevent overwriting
-  const filtersInitialized = useRef(false)
-  const isUpdatingURL = useRef(false)
-  const countByInitialized = useRef(false)
-  const previousCountByRef = useRef<Record<string, CountBySelection>>({})
-  const chartOverridesInitialized = useRef(false)
+  const {
+    presets,
+    showSavePresetDialog, setShowSavePresetDialog,
+    showManagePresetsDialog, setShowManagePresetsDialog,
+    showPresetsDropdown, setShowPresetsDropdown,
+    presetNameInput, setPresetNameInput,
+    editingPresetId, setEditingPresetId,
+    savePreset, applyPreset, deletePreset, renamePreset,
+    exportPresets, importPresets,
+  } = useFilterPresets({
+    identifier,
+    filters: filterState.filters,
+    countBySelections: countBy.countBySelections,
+    setFilters: filterState.setFilters,
+    setCountBySelections: countBy.setCountBySelections,
+  })
 
-  // Helper functions for URL persistence
-  const serializeFilters = (filters: Filter[]): string => {
-    return encodeState(filters)
-  }
+  const {
+    showPercentageLabels, setShowPercentageLabels,
+    showSettingsMenu, setShowSettingsMenu,
+    settingsButtonRef, settingsMenuRef,
+    getViewPreference, toggleViewPreference,
+    getSurvivalViewPreference, toggleSurvivalViewPreference,
+  } = useViewPreferences({ identifier })
 
-  const deserializeFilters = (encoded: string): Filter[] | null => {
-    return decodeState<Filter[]>(encoded)
-  }
+  // ── URL hash sync effect ────────────────────────────────────────
+  // Bridges filter and countBy state → URL hash + localStorage
 
-  const saveFiltersToLocalStorage = (filters: Filter[]) => {
-    try {
-      localStorage.setItem(`filters_${identifier}`, JSON.stringify(filters))
-    } catch (error) {
-      console.error('Failed to save filters to localStorage:', error)
-    }
-  }
+  useEffect(() => {
+    if (!filterState.filtersInitialized.current || !countBy.countByInitialized.current || isUpdatingURL.current) return
 
-  const loadFiltersFromLocalStorage = (): Filter[] | null => {
-    try {
-      const stored = localStorage.getItem(`filters_${identifier}`)
-      if (!stored) return null
-      const parsed: Filter[] = JSON.parse(stored)
-      if (parsed.length === 0) return []
-      return migrateFiltersToCurrentSchema(parsed)
-    } catch (error) {
-      console.error('Failed to load filters from localStorage:', error)
-      return null
-    }
-  }
+    const hashParts: string[] = []
 
-  const buildFiltersKey = (list?: Filter[]): string => JSON.stringify(list ?? [])
-  const currentFiltersKey = useMemo(() => buildFiltersKey(filters), [filters])
-
-  const serializeCountBySelections = (selections: Record<string, CountBySelection>): string => {
-    return encodeState(selections)
-  }
-
-  const deserializeCountBySelections = (encoded: string): Record<string, CountBySelection> | null => {
-    return decodeState<Record<string, CountBySelection>>(encoded)
-  }
-
-  const saveCountByToLocalStorage = (selections: Record<string, CountBySelection>) => {
-    try {
-      if (Object.keys(selections).length === 0) {
-        localStorage.removeItem(`countBy_${identifier}`)
-      } else {
-        localStorage.setItem(`countBy_${identifier}`, JSON.stringify(selections))
+    if (filterState.filters.length === 0) {
+      try {
+        localStorage.removeItem(`filters_${identifier}`)
+      } catch (error) {
+        console.error('Failed to clear filters from localStorage:', error)
       }
-    } catch (error) {
-      console.error('Failed to persist countBy selections:', error)
+    } else {
+      const encodedFilters = serializeFilters(filterState.filters)
+      hashParts.push(`filters=${encodedFilters}`)
+      filterState.saveFiltersToLocalStorage(filterState.filters)
     }
+
+    if (Object.keys(countBy.countBySelections).length === 0) {
+      try {
+        localStorage.removeItem(`countBy_${identifier}`)
+      } catch (error) {
+        console.error('Failed to clear countBy selections:', error)
+      }
+    } else {
+      const encodedCountBy = serializeCountBySelections(countBy.countBySelections)
+      if (encodedCountBy) {
+        hashParts.push(`countBy=${encodedCountBy}`)
+      }
+      try {
+        localStorage.setItem(`countBy_${identifier}`, JSON.stringify(countBy.countBySelections))
+      } catch (error) {
+        console.error('Failed to persist countBy selections:', error)
+      }
+    }
+
+    const newHash = hashParts.length > 0 ? `#${hashParts.join('&')}` : ''
+    const newURL = `${location.pathname}${location.search}${newHash}`
+
+    if (newHash !== location.hash) {
+      isUpdatingURL.current = true
+      navigate(newURL, { replace: true })
+      setTimeout(() => {
+        isUpdatingURL.current = false
+      }, 0)
+    }
+  }, [filterState.filters, countBy.countBySelections, location.pathname, location.search, location.hash, navigate, identifier])
+
+  // ── Range init effect ───────────────────────────────────────────
+  // Initializes custom range inputs when a filter menu opens (bridges filterState + loader)
+
+  useEffect(() => {
+    if (!filterState.activeFilterMenu) return
+    const { tableName, columnName, countKey } = filterState.activeFilterMenu
+    const key = rangeKey(tableName, columnName, countKey)
+    const baselineAgg = loader.getBaselineAggregation(tableName, columnName)
+    if (!baselineAgg || baselineAgg.display_type !== 'numeric') return
+    const stats = baselineAgg.numeric_stats
+    if (!stats) return
+
+    const defaultMin = stats.min !== null ? String(stats.min) : ''
+    const defaultMax = stats.max !== null ? String(stats.max) : ''
+
+    const selectedRanges = filterState.rangeSelections[key] ?? []
+    const singleRange = selectedRanges.length === 1 ? selectedRanges[0] : null
+
+    const nextMin = singleRange ? String(singleRange.start) : defaultMin
+    const nextMax = singleRange ? String(singleRange.end) : defaultMax
+
+    filterState.setCustomRangeInputs(prev => {
+      const current = prev[key]
+      if (current && current.min === nextMin && current.max === nextMax) {
+        return prev
+      }
+      return { ...prev, [key]: { min: nextMin, max: nextMax } }
+    })
+  }, [filterState.activeFilterMenu, loader.baselineAggregations, filterState.rangeSelections])
+
+  // ── Cross-cutting bridge functions ──────────────────────────────
+
+  const getCountByLabelFromCacheKey = (_tableName: string, cacheKey: string): string => {
+    if (cacheKey.startsWith('parent:')) {
+      const target = cacheKey.slice('parent:'.length)
+      return loader.getTableDisplayNameByName(target) || target
+    }
+    return 'Rows'
   }
 
-  const loadCountByFromLocalStorage = (): Record<string, CountBySelection> | null => {
-    try {
-      const stored = localStorage.getItem(`countBy_${identifier}`)
-      return stored ? JSON.parse(stored) : null
-    } catch (error) {
-      console.error('Failed to load countBy selections from localStorage:', error)
-      return null
-    }
+  const getCountByOptions = (tableName: string) => [
+    {
+      value: ROW_COUNT_KEY,
+      label: loader.getTableDisplayNameByName(tableName) || tableName
+    },
+    ...(loader.ancestorOptions[tableName] || []).map(option => ({
+      value: option.key,
+      label: loader.getTableDisplayNameByName(option.targetTable) || option.targetTable
+    }))
+  ]
+
+  const getCountIndicatorColor = (tableName: string, _cacheKey: string): string =>
+    loader.getTableColor(tableName)
+
+  const getCountByTableColor = (_tableName: string, cacheKey: string): string | null => {
+    const target = targetFromCacheKey(cacheKey)
+    return target ? loader.getTableColor(target) : null
   }
 
-  const saveChartOverridesToLocalStorage = (overrides: Record<string, string>) => {
-    if (!identifier) return
-    try {
-      persistChartOverrides(localStorage, identifier, overrides)
-    } catch (error) {
-      console.error('Failed to persist chart overrides:', error)
-    }
-  }
+  // ── Dashboard bridge functions ──────────────────────────────────
 
-  const loadChartOverridesFromLocalStorage = (): Record<string, string> | null => {
-    if (!identifier) return null
-    try {
-      return loadChartOverrides(localStorage, identifier)
-    } catch (error) {
-      console.error('Failed to load chart overrides from localStorage:', error)
-      return null
-    }
-  }
-
-
-
-  // Dashboard chart management
   const isOnDashboard = (tableName: string, columnName: string): boolean => {
-    const cacheKey = getEffectiveCacheKeyForChart(tableName, columnName)
+    const cacheKey = countBy.getEffectiveCacheKeyForChart(tableName, columnName)
     const target = targetFromCacheKey(cacheKey)
     return dashboardCharts.some(chart =>
       chart.tableName === tableName &&
@@ -233,37 +236,33 @@ function DatasetExplorer() {
   }
 
   const toggleDashboard = (tableName: string, columnName: string) => {
-    const cacheKey = getEffectiveCacheKeyForChart(tableName, columnName)
+    const cacheKey = countBy.getEffectiveCacheKeyForChart(tableName, columnName)
     const target = targetFromCacheKey(cacheKey)
     if (isOnDashboard(tableName, columnName)) {
-      // Remove from dashboard
       setDashboardCharts(prev =>
         prev.filter(chart =>
           !(chart.tableName === tableName && chart.columnName === columnName && chart.countByTarget === target)
         ))
     } else {
-      // Add to dashboard
       setDashboardCharts(prev => [...prev, { tableName, columnName, countByTarget: target, addedAt: new Date().toISOString() }])
-      ensureAggregationForCacheKey(tableName, cacheKey)
+      loader.ensureAggregationForCacheKey(tableName, cacheKey)
     }
   }
 
   const addAllChartsToTable = (tableName: string) => {
-    const tableAggregations = getAggregationsForTable(tableName)
-    const tableMetadata = columnMetadata[tableName]
+    const tableAggregations = loader.getAggregationsForTable(tableName)
+    const tableMetadata = loader.columnMetadata[tableName]
     if (!tableAggregations || tableAggregations.length === 0) return
     if (!tableMetadata || !Array.isArray(tableMetadata)) return
 
-    // Get all visible aggregations for this table
     const visibleAggregations = tableAggregations.filter(agg => {
       const metadata = tableMetadata.find(m => m.column_name === agg.column_name)
       return !metadata?.is_hidden
     })
 
-    // Add all charts that aren't already on dashboard
     const newCharts = visibleAggregations
       .map(agg => {
-        const cacheKey = getEffectiveCacheKeyForChart(tableName, agg.column_name)
+        const cacheKey = countBy.getEffectiveCacheKeyForChart(tableName, agg.column_name)
         const target = targetFromCacheKey(cacheKey)
         return {
           tableName,
@@ -284,857 +283,21 @@ function DatasetExplorer() {
       setDashboardCharts(prev => [...prev, ...newCharts])
       newCharts.forEach(chart => {
         const cacheKey = chart.countByTarget ? `parent:${chart.countByTarget}` : ROW_COUNT_KEY
-        ensureAggregationForCacheKey(chart.tableName, cacheKey)
+        loader.ensureAggregationForCacheKey(chart.tableName, cacheKey)
       })
     }
   }
 
-  const getTableChartCount = (tableName: string): number => {
-    const tableAggregations = baselineAggregations[tableName] || []
-    const tableMetadata = columnMetadata[tableName]
-    if (!tableMetadata || !Array.isArray(tableMetadata)) return 0
-
-    return tableAggregations.filter(agg => {
-      const metadata = tableMetadata.find(m => m.column_name === agg.column_name)
-      return !metadata?.is_hidden
-    }).length
-  }
-
-
-
-
-  // Restore filters from URL hash on mount
-  useEffect(() => {
-    if (filtersInitialized.current) return
-
-    // Parse hash fragment for filters
-    const hash = location.hash
-    const match = hash.match(/filters=([^&]+)/)
-    const encodedFilters = match ? match[1] : null
-
-    if (encodedFilters) {
-      const restored = deserializeFilters(encodedFilters)
-      if (restored && restored.length > 0) {
-        setFilters(migrateFiltersToCurrentSchema(restored))
-        filtersInitialized.current = true
-        return
-      }
-    }
-
-    // Fallback to localStorage if hash doesn't have filters
-    const localFilters = loadFiltersFromLocalStorage()
-    if (localFilters && localFilters.length > 0) {
-      setFilters(localFilters)
-    }
-
-    filtersInitialized.current = true
-  }, [location.hash, identifier])
-
-  // Update URL hash when filters change
-  useEffect(() => {
-    if (!filtersInitialized.current || !countByInitialized.current || isUpdatingURL.current) return
-
-    const hashParts: string[] = []
-
-    if (filters.length === 0) {
-      try {
-        localStorage.removeItem(`filters_${identifier}`)
-      } catch (error) {
-        console.error('Failed to clear filters from localStorage:', error)
-      }
-    } else {
-      const encodedFilters = serializeFilters(filters)
-      hashParts.push(`filters=${encodedFilters}`)
-      saveFiltersToLocalStorage(filters)
-    }
-
-    if (Object.keys(countBySelections).length === 0) {
-      try {
-        localStorage.removeItem(`countBy_${identifier}`)
-      } catch (error) {
-        console.error('Failed to clear countBy selections:', error)
-      }
-    } else {
-      const encodedCountBy = serializeCountBySelections(countBySelections)
-      if (encodedCountBy) {
-        hashParts.push(`countBy=${encodedCountBy}`)
-      }
-      saveCountByToLocalStorage(countBySelections)
-    }
-
-    const newHash = hashParts.length > 0 ? `#${hashParts.join('&')}` : ''
-    const newURL = `${location.pathname}${location.search}${newHash}`
-
-    if (newHash !== location.hash) {
-      isUpdatingURL.current = true
-      navigate(newURL, { replace: true })
-      setTimeout(() => {
-        isUpdatingURL.current = false
-      }, 0)
-    }
-  }, [filters, countBySelections, location.pathname, location.search, location.hash, navigate, identifier])
-
-
-  useEffect(() => {
-    if (!countByReady) return
-    loadDataset()
-  }, [id, database, countByReady])
-
-
-  useEffect(() => {
-    if (!dataset?.tables) {
-      setAncestorOptions({})
-      return
-    }
-    let cancelled = false
-    const tablesSnapshot = dataset.tables
-    Promise.resolve().then(() => {
-      if (cancelled) return
-      const options = buildAncestorOptions(tablesSnapshot)
-      if (cancelled) return
-      setAncestorOptions(options)
-      setCountBySelections(prev => normalizeCountBySelections(prev, options))
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [dataset])
-
-  useEffect(() => {
-    // Reload aggregations when filters change
-    if (dataset && countByReady) {
-      reloadAggregations()
-    }
-  }, [filters, dataset, countByReady])
-
-  useEffect(() => {
-    if (!dataset || !countByInitialized.current || !countByReady) return
-
-    const shouldUseDatabaseAPI = isDatabaseMode || dataset.database_type === 'connected'
-    const dbIdentifier = isDatabaseMode ? identifier : dataset.database_name
-
-    dataset.tables.forEach(table => {
-      const previousKey = previousCountByRef.current[table.name]
-        ? `parent:${previousCountByRef.current[table.name].targetTable}`
-        : 'rows'
-      const currentSelection = countBySelections[table.name]
-      const currentKey = currentSelection ? `parent:${currentSelection.targetTable}` : 'rows'
-
-      if (previousKey !== currentKey) {
-        const cachedEntry = aggregations[table.name]?.[currentKey]
-        if (isCacheEntryFresh(cachedEntry, currentFiltersKey)) {
-          return
-        }
-        loadTableAggregations(table.id, table.name, {
-          useDbAPI: shouldUseDatabaseAPI,
-          dbName: dbIdentifier,
-          datasetId: dataset.id,
-          cacheKey: currentKey
-        })
-      }
-    })
-
-    previousCountByRef.current = countBySelections
-  }, [countBySelections, dataset, isDatabaseMode, identifier, aggregations, currentFiltersKey])
-
-  const reloadAggregations = async () => {
-    if (!dataset || !countByReady) return
-    // Determine if we should use database API based on current dataset
-    const shouldUseDatabaseAPI = isDatabaseMode || dataset.database_type === 'connected'
-    const dbIdentifier = isDatabaseMode ? identifier : dataset.database_name
-
-    // Send ALL filters to ALL tables and let the backend figure out cross-table filtering
-    // The backend will detect which filters are for each table using the tableName property
-    for (const table of dataset.tables) {
-      const selection = countBySelections[table.name] ?? null
-      const cacheKey = getCountByCacheKey(table.name)
-      await loadTableAggregations(table.id, table.name, {
-        useDbAPI: shouldUseDatabaseAPI,
-        dbName: dbIdentifier,
-        datasetId: dataset.id,
-        tableFilters: filters,
-        cacheKey,
-        selectionOverride: selection
-      })
-    }
-  }
-
-  useEffect(() => {
-    if (!dataset || !countByReady) return
-    Object.entries(chartCountOverrides).forEach(([key, cacheKey]) => {
-      const [tableName, columnName] = key.split('.')
-      if (tableName && columnName) {
-        ensureAggregationForCacheKey(tableName, cacheKey)
-      }
-    })
-  }, [chartCountOverrides, dataset, countByReady])
-
-  useEffect(() => {
-    if (!dataset || !countByReady) return
-    const shouldUseDatabaseAPI = isDatabaseMode || dataset.database_type === 'connected'
-    const dbIdentifier = isDatabaseMode ? identifier : dataset.database_name
-
-    dashboardCharts.forEach(chart => {
-      const key = getDashboardChartKey(chart)
-      if (!visibleDashboardKeys[key]) return
-      const table = dataset.tables.find(t => t.name === chart.tableName)
-      if (!table) return
-      const cacheKey = chart.countByTarget ? `parent:${chart.countByTarget}` : ROW_COUNT_KEY
-      const cachedEntry = aggregations[chart.tableName]?.[cacheKey]
-      if (isCacheEntryFresh(cachedEntry, currentFiltersKey)) return
-      loadTableAggregations(table.id, table.name, {
-        useDbAPI: shouldUseDatabaseAPI,
-        dbName: dbIdentifier,
-        datasetId: dataset.id,
-        cacheKey,
-        selectionOverride: chart.countByTarget ? { mode: 'parent', targetTable: chart.countByTarget } : null
-      })
-    })
-  }, [dashboardCharts, dataset, countByReady, aggregations, isDatabaseMode, identifier, currentFiltersKey, visibleDashboardKeys])
-
-  const loadDataset = async () => {
-    try {
-      setLoading(true)
-      setError(null)
-      setAggregations({})
-      setBaselineAggregations({})
-
-      // Use different API endpoint based on mode
-      const apiPath = isDatabaseMode ? `/databases/${identifier}` : `/datasets/${identifier}`
-      const response = await api.get(apiPath)
-
-      const loadedDataset = response.data.dataset
-      setDataset(loadedDataset)
-      setBaselineAggregations({})
-      setCustomRangeInputs({})
-      setRangeSelections({})
-      setActiveFilterMenu(null)
-
-      // Initialize active tab to dashboard
-      setActiveTab('dashboard')
-
-      // Determine if this dataset uses database API
-      const shouldUseDatabaseAPI = isDatabaseMode || loadedDataset.database_type === 'connected'
-      const dbIdentifier = isDatabaseMode ? identifier : loadedDataset.database_name
-
-      // Load aggregations and column metadata for all tables
-      for (const table of loadedDataset.tables) {
-        await loadTableAggregations(table.id, table.name, {
-          storeBaseline: true,
-          useDbAPI: shouldUseDatabaseAPI,
-          dbName: dbIdentifier,
-          datasetId: loadedDataset.id,
-          cacheKey: ROW_COUNT_KEY
-        })
-        await loadColumnMetadata(table.id, table.name, {
-          useDbAPI: shouldUseDatabaseAPI,
-          dbName: dbIdentifier,
-          datasetId: loadedDataset.id
-        })
-      }
-    } catch (error) {
-      console.error('Failed to load dataset:', error)
-      setError(error instanceof Error ? error.message : 'Failed to load dataset')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const loadTableAggregations = async (
-    tableId: string,
-    tableName: string,
-    options?: {
-      storeBaseline?: boolean
-      useDbAPI?: boolean
-      dbName?: string
-      datasetId?: string
-      tableFilters?: Filter[]
-      cacheKey?: string
-      selectionOverride?: CountBySelection | null
-    }
-  ) => {
-    try {
-      // Use table-specific filters if provided, otherwise fall back to global filters
-      const activeFilters = options?.tableFilters !== undefined ? options.tableFilters : filters
-      const requestFiltersKey = buildFiltersKey(activeFilters)
-      const params: Record<string, any> = activeFilters.length > 0 ? { filters: JSON.stringify(activeFilters) } : {}
-      // Use provided values or fall back to computed values
-      const shouldUseDbAPI = options?.useDbAPI !== undefined ? options.useDbAPI : usesDatabaseAPI
-      const dbIdentifier = options?.dbName || databaseIdentifier
-      const datasetParam = options?.datasetId || datasetIdentifier
-
-      const apiPath = shouldUseDbAPI
-        ? `/databases/${dbIdentifier}/tables/${tableId}/aggregations`
-        : `/datasets/${identifier}/tables/${tableId}/aggregations`
-      if (shouldUseDbAPI && datasetParam) {
-        params.datasetId = datasetParam
-      }
-      const selection = options?.selectionOverride ?? countBySelections[tableName]
-      const cacheKey = options?.cacheKey ?? getCountByCacheKey(tableName)
-      if (selection?.mode === 'parent') {
-        params.countBy = `parent:${selection.targetTable}`
-      }
-
-      const response = await api.get(apiPath, { params })
-      setAggregations(prev => {
-        const previousTableCache = prev[tableName] || {}
-        const nextEntry: AggregationCacheEntry = {
-          data: response.data.aggregations,
-          filtersKey: requestFiltersKey,
-          timestamp: Date.now()
-        }
-        const nextTableCache: Record<string, AggregationCacheEntry> = {
-          ...previousTableCache,
-          [cacheKey]: nextEntry
-        }
-
-        const tableKeys = Object.keys(nextTableCache)
-        if (tableKeys.length > CACHE_MAX_ENTRIES_PER_TABLE) {
-          const sortedByAge = tableKeys
-            .slice()
-            .sort((a, b) => nextTableCache[a].timestamp - nextTableCache[b].timestamp)
-          while (sortedByAge.length > CACHE_MAX_ENTRIES_PER_TABLE) {
-            const oldestKey = sortedByAge.shift()
-            if (oldestKey) {
-              delete nextTableCache[oldestKey]
-            }
-          }
-        }
-
-        return {
-          ...prev,
-          [tableName]: nextTableCache
-        }
-      })
-      if (options?.storeBaseline && cacheKey === ROW_COUNT_KEY) {
-        setBaselineAggregations(prev => ({ ...prev, [tableName]: response.data.aggregations }))
-      }
-    } catch (error) {
-      console.error('Failed to load table aggregations:', error)
-      setError(error instanceof Error ? error.message : 'Failed to load table aggregations')
-    }
-  }
-
-  const loadColumnMetadata = async (
-    tableId: string,
-    tableName: string,
-    options?: { useDbAPI?: boolean; dbName?: string; datasetId?: string }
-  ) => {
-    try {
-      // Use provided values or fall back to computed values
-      const shouldUseDbAPI = options?.useDbAPI !== undefined ? options.useDbAPI : usesDatabaseAPI
-      const dbIdentifier = options?.dbName || databaseIdentifier
-      const datasetParam = options?.datasetId || datasetIdentifier
-
-      const apiPath = shouldUseDbAPI
-        ? `/databases/${dbIdentifier}/tables/${tableId}/columns`
-        : `/datasets/${identifier}/tables/${tableId}/columns`
-      const response = await api.get(apiPath, {
-        params: shouldUseDbAPI && datasetParam ? { datasetId: datasetParam } : undefined
-      })
-      setColumnMetadata(prev => ({ ...prev, [tableName]: response.data.columns }))
-    } catch (error) {
-      console.error('Failed to load column metadata:', error)
-      setError(error instanceof Error ? error.message : 'Failed to load column metadata')
-    }
-  }
-
-  const getBaselineAggregation = (tableName: string, columnName: string): ColumnAggregation | undefined => {
-    const tableAggregations = baselineAggregations[tableName]
-    if (!tableAggregations) return undefined
-    return tableAggregations.find(agg => agg.column_name === columnName)
-  }
-
-  const getAggregation = (tableName: string, columnName: string, overrideKey?: string): ColumnAggregation | undefined => {
-    const tableAggregations = getAggregationsForTable(tableName, overrideKey)
-    if (!tableAggregations) return undefined
-    return tableAggregations.find(agg => agg.column_name === columnName)
-  }
-
-  const getColumnMetadata = (tableName: string, columnName: string): ColumnMetadata | undefined => {
-    const metadata = columnMetadata[tableName]
-    if (!metadata) return undefined
-    return metadata.find(col => col.column_name === columnName)
-  }
-
-  const getDisplayTitle = (tableName: string, columnName: string): string => {
-    const metadata = getColumnMetadata(tableName, columnName)
-    return metadata?.display_name || columnName.replace(/_/g, ' ')
-  }
-
-  const getCountByCacheKey = (tableName: string, override?: string): string => {
-    if (override) return override
-    const selection = countBySelections[tableName]
-    return selection ? `parent:${selection.targetTable}` : ROW_COUNT_KEY
-  }
-
-  const isCacheEntryFresh = (entry?: { timestamp: number; filtersKey?: string }, filtersKey?: string) => {
-    if (!entry) return false
-    if (filtersKey && entry.filtersKey !== filtersKey) return false
-    return Date.now() - entry.timestamp < CACHE_TTL_MS
-  }
-
-  const getAggregationsForTable = (tableName: string, override?: string): ColumnAggregation[] | undefined => {
-    const cacheKey = getCountByCacheKey(tableName, override)
-    const entry = aggregations[tableName]?.[cacheKey]
-    if (!isCacheEntryFresh(entry, currentFiltersKey)) return undefined
-    return entry?.data
-  }
-
-  const getSurvivalEntryKey = (timeColumn: string, statusColumn: string, cacheKey: string) =>
-    `${timeColumn}::${statusColumn}::${cacheKey}`
-
-  const getSurvivalCurve = (
-    tableName: string,
-    timeColumn: string,
-    statusColumn: string,
-    cacheKey?: string
-  ): SurvivalCurvePoint[] | undefined => {
-    const key = cacheKey ?? getCountByCacheKey(tableName)
-    const entryKey = getSurvivalEntryKey(timeColumn, statusColumn, key)
-    const entry = survivalCurves[tableName]?.[entryKey]
-    if (!isCacheEntryFresh(entry, currentFiltersKey)) return undefined
-    return entry?.data
-  }
-
-  const loadSurvivalCurve = async (
-    table: Table,
-    timeColumn: string,
-    statusColumn: string,
-    cacheKey?: string
-  ) => {
-    const key = cacheKey ?? getCountByCacheKey(table.name)
-    const entryKey = getSurvivalEntryKey(timeColumn, statusColumn, key)
-    const cached = survivalCurves[table.name]?.[entryKey]
-    if (isCacheEntryFresh(cached, currentFiltersKey)) return
-
-    const requestKey = `${table.name}|${entryKey}|${currentFiltersKey}`
-    if (survivalRequests.current.has(requestKey)) return
-    survivalRequests.current.add(requestKey)
-
-    try {
-      const params: Record<string, any> = {
-        timeColumn,
-        statusColumn
-      }
-      if (filters.length > 0) {
-        params.filters = JSON.stringify(filters)
-      }
-      const selection = countBySelections[table.name]
-      if (selection?.mode === 'parent') {
-        params.countBy = `parent:${selection.targetTable}`
-      }
-
-      const response = await api.get(`/datasets/${identifier}/tables/${table.id}/survival`, { params })
-      setSurvivalCurves(prev => {
-        const tableCache = prev[table.name] || {}
-        const nextEntry: SurvivalCacheEntry = {
-          data: response.data.curve || [],
-          filtersKey: currentFiltersKey,
-          countByKey: key,
-          statusColumn,
-          timestamp: Date.now()
-        }
-        return {
-          ...prev,
-          [table.name]: {
-            ...tableCache,
-            [entryKey]: nextEntry
-          }
-        }
-      })
-    } catch (error) {
-      console.error('Failed to load survival curve:', error)
-    } finally {
-      survivalRequests.current.delete(requestKey)
-    }
-  }
-
-  const ensureSurvivalCurve = (
-    table: Table,
-    timeColumn: string,
-    statusColumn: string,
-    cacheKey?: string
-  ) => {
-    const key = cacheKey ?? getCountByCacheKey(table.name)
-    const entryKey = getSurvivalEntryKey(timeColumn, statusColumn, key)
-    const cached = survivalCurves[table.name]?.[entryKey]
-    if (isCacheEntryFresh(cached, currentFiltersKey)) return
-    loadSurvivalCurve(table, timeColumn, statusColumn, key)
-  }
-
-  const findSurvivalStatusColumn = (tableName: string, timeColumn: string): string | null => {
-    const metadata = columnMetadata[tableName]
-    if (!metadata) return null
-    const statusColumns = metadata.filter(col => col.display_type === 'survival_status')
-    if (statusColumns.length === 0) return null
-    const base = timeColumn.replace(/_(months|days|time)$/i, '')
-    const matched = statusColumns.find(col => col.column_name.startsWith(base))
-    return (matched || statusColumns[0]).column_name
-  }
-
-  const buildAncestorOptions = (tables: Table[]): Record<string, AncestorOption[]> => {
-    const tableMap = new Map(tables.map(t => [t.name, t]))
-    const options: Record<string, AncestorOption[]> = {}
-
-    tables.forEach(source => {
-      const result: AncestorOption[] = []
-      const queue: Array<{ tableName: string; path: MetricPathSegment[] }> = [{ tableName: source.name, path: [] }]
-      const visited = new Set<string>([source.name])
-
-      while (queue.length > 0) {
-        const { tableName, path } = queue.shift()!
-        const tableMeta = tableMap.get(tableName)
-        if (!tableMeta) continue
-
-        for (const rel of tableMeta.relationships || []) {
-          const nextTable = rel.referenced_table
-          const segment: MetricPathSegment = { from_table: tableName, via_column: rel.foreign_key, to_table: nextTable }
-          const nextPath = [...path, segment]
-
-          if (nextPath.length > MAX_ANCESTOR_DEPTH) {
-            continue
-          }
-
-          if (!visited.has(nextTable)) {
-            queue.push({ tableName: nextTable, path: nextPath })
-            visited.add(nextTable)
-          }
-
-          if (nextPath.length > 0) {
-            const targetMeta = tableMap.get(nextTable)
-            const labelParts = nextPath.map(seg => `${seg.from_table}.${seg.via_column}`)
-            const label = `${targetMeta?.displayName || targetMeta?.name || nextTable} via ${labelParts.join(' → ')}`
-            const key = `parent:${nextTable}`
-            result.push({ targetTable: nextTable, label, key, path: nextPath })
-          }
-        }
-      }
-
-      const unique = new Map<string, AncestorOption>()
-      result.forEach(option => {
-        if (!unique.has(option.targetTable)) {
-          unique.set(option.targetTable, option)
-        }
-      })
-      options[source.name] = Array.from(unique.values()).sort((a, b) => a.label.localeCompare(b.label))
-    })
-
-    return options
-  }
-
-  const normalizeCountBySelections = (
-    selections: Record<string, CountBySelection>,
-    options: Record<string, AncestorOption[]>
-  ): Record<string, CountBySelection> => {
-    let changed = false
-    const next: Record<string, CountBySelection> = {}
-
-    Object.entries(selections).forEach(([table, selection]) => {
-      if (!selection) return
-      const tableOptions = options[table]
-      if (!tableOptions || tableOptions.length === 0) {
-        changed = true
-        return
-      }
-      const match = tableOptions.find(opt => opt.targetTable === selection.targetTable)
-      if (!match) {
-        changed = true
-        return
-      }
-      next[table] = selection
-    })
-
-    return changed ? next : selections
-  }
-
-  const getTableDisplayNameByName = (tableName?: string): string | undefined => {
-    if (!tableName || !dataset?.tables) return tableName
-    const match = dataset.tables.find(t => t.name === tableName)
-    return match?.displayName || tableName
-  }
-
-  const getMetricLabels = (aggregation?: ColumnAggregation) => {
-    if (!aggregation || aggregation.metric_type !== 'parent' || !aggregation.metric_parent_table) {
-      return { short: 'rows', long: 'Rows' }
-    }
-    const parentName = getTableDisplayNameByName(aggregation.metric_parent_table) || aggregation.metric_parent_table
-    return {
-      short: `unique ${parentName.toLowerCase()}`,
-      long: `Unique ${parentName}`
-    }
-  }
-
-  const formatMetricPath = (aggregation?: ColumnAggregation): string | null => {
-    if (!aggregation || aggregation.metric_type !== 'parent' || !aggregation.metric_path || aggregation.metric_path.length === 0) {
-      return null
-    }
-    const target = aggregation.metric_parent_table
-    const targetLabel = target ? getTableDisplayNameByName(target) || target : ''
-    const chain = aggregation.metric_path
-      .map(segment => `${segment.from_table}.${segment.via_column}`)
-      .join(' → ')
-    return targetLabel ? `${targetLabel} via ${chain}` : chain
-  }
-
-  const metricsMatch = (a?: ColumnAggregation, b?: ColumnAggregation) => {
-    if (!a || !b) return false
-    const typeA = a.metric_type || 'rows'
-    const typeB = b.metric_type || 'rows'
-    if (typeA !== typeB) return false
-    if (typeA === 'parent') {
-      const pathA = JSON.stringify(a.metric_path || [])
-      const pathB = JSON.stringify(b.metric_path || [])
-      return a.metric_parent_table === b.metric_parent_table && pathA === pathB
-    }
-    return true
-  }
-
-  const normalizeFilterValue = (value: string | number | null | undefined): string => {
-    if (value === null || value === undefined) return ''
-    return String(value)
-  }
-
-  const formatRangeValue = (value: number): string => {
-    if (!Number.isFinite(value)) return '–'
-    if (Number.isInteger(value)) return value.toString()
-    return value.toFixed(2)
-  }
-
-  const chartKey = (tableName: string, columnName: string) => `${tableName}.${columnName}`
-
-  const getChartOverrideKey = (tableName: string, columnName: string): string | undefined =>
-    chartCountOverrides[chartKey(tableName, columnName)]
-
-  const getEffectiveCacheKeyForChart = (tableName: string, columnName: string): string => {
-    const override = getChartOverrideKey(tableName, columnName)
-    return override ?? getCountByCacheKey(tableName)
-  }
-
-  const parseSelectionFromCacheKey = (key?: string): CountBySelection | null => {
-    if (!key) return null
-    if (key.startsWith('parent:')) {
-      return { mode: 'parent', targetTable: key.slice('parent:'.length) }
-    }
-    return null
-  }
-
-  const targetFromCacheKey = (key?: string): string | null => {
-    if (!key) return null
-    return key.startsWith('parent:') ? key.slice('parent:'.length) : null
-  }
-
-  const setChartOverrideForChart = (tableName: string, columnName: string, override?: string) => {
-    setChartCountOverrides(prev => {
-      const key = chartKey(tableName, columnName)
-      const defaultKey = getCountByCacheKey(tableName)
-      if (!override || override === defaultKey) {
-        if (!(key in prev)) return prev
-        const { [key]: _removed, ...rest } = prev
-        return rest
-      }
-      if (prev[key] === override) return prev
-      return { ...prev, [key]: override }
-    })
-  }
-
-  const ensureAggregationForCacheKey = (tableName: string, cacheKey: string) => {
-    if (!dataset || !countByReady) return
-    const table = dataset.tables.find(t => t.name === tableName)
-    if (!table) return
-    const cachedEntry = aggregations[tableName]?.[cacheKey]
-    if (isCacheEntryFresh(cachedEntry, currentFiltersKey)) return
-
-    const shouldUseDatabaseAPI = isDatabaseMode || dataset.database_type === 'connected'
-    const dbIdentifier = isDatabaseMode ? identifier : dataset.database_name
-    const selectionOverride = parseSelectionFromCacheKey(cacheKey)
-
-    loadTableAggregations(table.id, table.name, {
-      useDbAPI: shouldUseDatabaseAPI,
-      dbName: dbIdentifier,
-      datasetId: dataset.id,
-      cacheKey,
-      selectionOverride
-    })
-  }
-
-  const getCountByLabelFromCacheKey = (_tableName: string, cacheKey: string): string => {
-    if (cacheKey.startsWith('parent:')) {
-      const target = cacheKey.slice('parent:'.length)
-      return getTableDisplayNameByName(target) || target
-    }
-    return 'Rows'
-  }
-
-  const getCountByOptions = (tableName: string) => [
-    {
-      value: ROW_COUNT_KEY,
-      label: getTableDisplayNameByName(tableName) || tableName
-    },
-    ...(ancestorOptions[tableName] || []).map(option => ({
-      value: option.key,
-      label: getTableDisplayNameByName(option.targetTable) || option.targetTable
-    }))
-  ]
-
-  const getCountIndicatorColor = (tableName: string, _cacheKey: string): string => {
-    // Color bar represents the data source table
-    return getTableColor(tableName)
-  }
-
-  const getCountByTableColor = (_tableName: string, cacheKey: string): string | null => {
-    // Border color represents the count-by table (when different from data source)
-    const target = targetFromCacheKey(cacheKey)
-    return target ? getTableColor(target) : null
-  }
-
-  const renderCountIndicator = ({
-    menuKey,
-    indicatorColor,
-    borderColor,
-    label,
-    options,
-    currentValue,
-    onSelect,
-    buttonLabel,
-    size = 'default'
-  }: {
-    menuKey: string
-    indicatorColor: string
-    borderColor?: string | null
-    label: string
-    options: Array<{ value: string; label: string }>
-    currentValue: string
-    onSelect: (value: string) => void
-    buttonLabel: string
-    size?: 'default' | 'large'
-  }) => {
-    const isOpen = activeCountMenuKey === menuKey
-    const hasBorder = borderColor && borderColor !== indicatorColor
-
-    // Size variants
-    const dimensions = size === 'large'
-      ? { width: hasBorder ? '16px' : '12px', height: '40px' }
-      : { width: hasBorder ? '14px' : '10px', height: '22px' }
-
-    return (
-      <div style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-        <button
-          type="button"
-          aria-label={buttonLabel}
-          title={`${label} (click to change)`}
-          onClick={event => {
-            event.stopPropagation()
-            setActiveCountMenuKey(prev => (prev === menuKey ? null : menuKey))
-          }}
-          style={{
-            width: dimensions.width,
-            height: dimensions.height,
-            borderRadius: '4px',
-            border: hasBorder ? `2px solid ${borderColor}` : 'none',
-            background: indicatorColor,
-            cursor: 'pointer',
-            padding: 0
-          }}
-        />
-        {isOpen && (
-          <div
-            style={{
-              position: 'absolute',
-              top: '120%',
-              left: 0,
-              background: 'white',
-              border: '1px solid #ddd',
-              borderRadius: '6px',
-              boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-              padding: '0.35rem 0.4rem',
-              zIndex: 20,
-              minWidth: '160px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '0.3rem'
-            }}
-            onClick={event => event.stopPropagation()}
-          >
-            {options.map(option => {
-              const active = option.value === currentValue
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  onClick={() => {
-                    onSelect(option.value)
-                    setActiveCountMenuKey(null)
-                  }}
-                  style={{
-                    textAlign: 'left',
-                    border: active ? '1px solid #1976D2' : '1px solid transparent',
-                    borderRadius: '4px',
-                    background: active ? '#E3F2FD' : 'transparent',
-                    color: '#333',
-                    fontSize: '0.72rem',
-                    padding: '0.15rem 0.35rem',
-                    cursor: 'pointer'
-                  }}
-                >
-                  {option.label}
-                </button>
-              )
-            })}
-          </div>
-        )}
-      </div>
-    )
-  }
-
-  const renderDashboardCountIndicator = (
-    chartIndex: number,
-    tableName: string,
-    columnName: string,
-    cacheKey: string
-  ) => {
-    const indicatorColor = getCountIndicatorColor(tableName, cacheKey)
-    const borderColor = getCountByTableColor(tableName, cacheKey)
-    const label = getCountByLabelFromCacheKey(tableName, cacheKey)
-    const options = getCountByOptions(tableName)
-    return renderCountIndicator({
-      menuKey: `${DASHBOARD_SCOPE_KEY}:${chartIndex}`,
-      indicatorColor,
-      borderColor,
-      label,
-      options,
-      currentValue: cacheKey,
-      buttonLabel: `Change count-by for dashboard chart ${tableName}.${columnName}`,
-      onSelect: value => handleDashboardChartCountChange(chartIndex, tableName, value)
-    })
-  }
-
-  const renderTabCountIndicator = (tableName: string, cacheKey: string) => {
-    const indicatorColor = getCountIndicatorColor(tableName, cacheKey)
-    const borderColor = getCountByTableColor(tableName, cacheKey)
-    const label = getCountByLabelFromCacheKey(tableName, cacheKey)
-    const options = getCountByOptions(tableName)
-    return renderCountIndicator({
-      menuKey: `tab:${tableName}`,
-      indicatorColor,
-      borderColor,
-      label,
-      options,
-      currentValue: cacheKey,
-      buttonLabel: `Change count-by for ${tableName}`,
-      onSelect: value => handleCountByChange(tableName, value),
-      size: 'large'
-    })
-  }
+  // ── Count-by override handlers ──────────────────────────────────
 
   const handleChartCountOverrideChange = (tableName: string, columnName: string, value: string) => {
-    const defaultKey = getCountByCacheKey(tableName)
+    const defaultKey = countBy.getCountByCacheKey(tableName)
     if (value === defaultKey) {
-      setChartOverrideForChart(tableName, columnName)
+      countBy.setChartOverrideForChart(tableName, columnName)
     } else {
-      setChartOverrideForChart(tableName, columnName, value)
+      countBy.setChartOverrideForChart(tableName, columnName, value)
     }
-    ensureAggregationForCacheKey(tableName, value)
+    loader.ensureAggregationForCacheKey(tableName, value)
   }
 
   const handleDashboardChartCountChange = (chartIndex: number, tableName: string, value: string) => {
@@ -1144,573 +307,109 @@ function DatasetExplorer() {
         idx === chartIndex ? { ...chart, countByTarget: nextTarget } : chart
       )
     )
-    ensureAggregationForCacheKey(tableName, value)
+    loader.ensureAggregationForCacheKey(tableName, value)
   }
 
-  /**
-   * Determine which table a filter applies to for cache lookups / backend requests.
-   *
-   * Note: {@link Filter.countByKey} is purely client-side metadata that scopes UI controls.
-   * The backend only inspects {@link Filter.tableName} to build JOIN paths, so we never rewrite
-   * tableName when users select different ancestor count targets.
-   */
-  const getFilterTableNameForCacheKey = (filter: Filter): string | undefined => filter.tableName
+  // ── Count indicator wrappers ────────────────────────────────────
 
-  // Helper: Get all effective filters (direct + propagated) for all tables
-  const getAllEffectiveFilters = (): Record<string, { direct: Filter[]; propagated: Filter[] }> => {
-    if (!dataset) return {}
-
-    const result: Record<string, { direct: Filter[]; propagated: Filter[] }> = {}
-
-    // Initialize all tables
-    for (const table of dataset.tables) {
-      result[table.name] = { direct: [], propagated: [] }
-    }
-
-    // Group filters by their tableName property
-    for (const filter of filters) {
-      const filterTableName = getFilterTableNameForCacheKey(filter)
-      if (!filterTableName) continue
-
-      // This filter belongs to filterTableName
-      // It's "direct" for that table, "propagated" for other tables with relationships
-      for (const table of dataset.tables) {
-        if (table.name === filterTableName) {
-          // Direct filter
-          result[table.name].direct.push(filter)
-        } else {
-          // Check if there's a relationship path between these tables (including transitive)
-          const path = findRelationshipPath(table.name, filterTableName, dataset.tables)
-          const hasRelationship = path !== null
-
-          if (hasRelationship) {
-            // This is a propagated filter for this table
-            result[table.name].propagated.push(filter)
-          }
-        }
-      }
-    }
-
-    return result
-  }
-
-  const hasColumnFilter = (column: string, countKey?: string): boolean => {
-    const resolvedKey = countKey ?? ROW_COUNT_KEY
-    return filters.some(f => {
-      const actual = unwrapNot(f)
-      if (!actual || !filterContainsColumn(actual, column)) return false
-      return getFilterCountKey(f) === resolvedKey
-    })
-  }
-
-  const removeColumnFilters = (prev: Filter[], column: string, countKey?: string): Filter[] => {
-    const resolvedKey = countKey ?? ROW_COUNT_KEY
-    return prev.filter(filter => {
-      const actualFilter = unwrapNot(filter)
-      if (!actualFilter || !filterContainsColumn(actualFilter, column)) return true
-      return getFilterCountKey(filter) !== resolvedKey
-    })
-  }
-
-  const clearColumnFilter = (tableName: string, columnName: string, countKey?: string) => {
-    setFilters(prev => removeColumnFilters(prev, columnName, countKey))
-    const key = rangeKey(tableName, columnName, countKey)
-    setCustomRangeInputs(prev => {
-      if (!(key in prev)) return prev
-      const { [key]: _removed, ...rest } = prev
-      return rest
-    })
-    setRangeSelections(prev => {
-      if (!(key in prev)) return prev
-      const { [key]: _removed, ...rest } = prev
-      return rest
-    })
-  }
-
-  const updateColumnRanges = (
+  const renderDashboardCountIndicator = (
+    chartIndex: number,
     tableName: string,
     columnName: string,
-    updater: (ranges: Array<{ start: number; end: number }>) => Array<{ start: number; end: number }>,
-    countKey?: string
-  ) => {
-    const key = rangeKey(tableName, columnName, countKey)
-    let nextRanges: Array<{ start: number; end: number }> = []
-    setRangeSelections(prev => {
-      const prevRanges = prev[key] ?? []
-      nextRanges = updater(prevRanges)
-      nextRanges = nextRanges
-        .slice()
-        .sort((a, b) => (a.start - b.start) || (a.end - b.end))
-      const unchanged = prevRanges.length === nextRanges.length && prevRanges.every((range, idx) => rangesEqual(range, nextRanges[idx]))
-      if (unchanged) {
-        nextRanges = prevRanges
-        return prev
-      }
-      const updated = { ...prev }
-      if (nextRanges.length === 0) {
-        delete updated[key]
-      } else {
-        updated[key] = nextRanges
-      }
-      return updated
-    })
+    cacheKey: string
+  ) => (
+    <CountIndicator
+      menuKey={`${DASHBOARD_SCOPE_KEY}:${chartIndex}`}
+      indicatorColor={getCountIndicatorColor(tableName, cacheKey)}
+      borderColor={getCountByTableColor(tableName, cacheKey)}
+      label={getCountByLabelFromCacheKey(tableName, cacheKey)}
+      options={getCountByOptions(tableName)}
+      currentValue={cacheKey}
+      buttonLabel={`Change count-by for dashboard chart ${tableName}.${columnName}`}
+      onSelect={value => handleDashboardChartCountChange(chartIndex, tableName, value)}
+    />
+  )
 
-    setFilters(prev => {
-      const without = removeColumnFilters(prev, columnName, countKey)
-      if (nextRanges.length === 0) return without
-      if (nextRanges.length === 1) {
-        const range = nextRanges[0]
-        return [
-          ...without,
-          {
-            column: columnName,
-            operator: 'between',
-            value: [range.start, range.end],
-            tableName,
-            countByKey: countKey
-          }
-        ]
-      }
-      const orFilters = nextRanges.map(range => ({ column: columnName, operator: 'between' as const, value: [range.start, range.end] }))
-      return [
-        ...without,
-        { column: columnName, or: orFilters, tableName, countByKey: countKey }
-      ]
-    })
-  }
+  const renderTabCountIndicator = (tableName: string, cacheKey: string) => (
+    <CountIndicator
+      menuKey={`tab:${tableName}`}
+      indicatorColor={getCountIndicatorColor(tableName, cacheKey)}
+      borderColor={getCountByTableColor(tableName, cacheKey)}
+      label={getCountByLabelFromCacheKey(tableName, cacheKey)}
+      options={getCountByOptions(tableName)}
+      currentValue={cacheKey}
+      buttonLabel={`Change count-by for ${tableName}`}
+      onSelect={value => countBy.handleCountByChange(tableName, value)}
+      size="large"
+    />
+  )
 
-  useEffect(() => {
-    if (!activeFilterMenu) return
-    const { tableName, columnName, countKey } = activeFilterMenu
-    const key = rangeKey(tableName, columnName, countKey)
-    const baselineAgg = getBaselineAggregation(tableName, columnName)
-    if (!baselineAgg || baselineAgg.display_type !== 'numeric') return
-    const stats = baselineAgg.numeric_stats
-    if (!stats) return
-
-    const defaultMin = stats.min !== null ? String(stats.min) : ''
-    const defaultMax = stats.max !== null ? String(stats.max) : ''
-
-    const selectedRanges = rangeSelections[key] ?? []
-    const singleRange = selectedRanges.length === 1 ? selectedRanges[0] : null
-
-    const nextMin = singleRange ? String(singleRange.start) : defaultMin
-    const nextMax = singleRange ? String(singleRange.end) : defaultMax
-
-    setCustomRangeInputs(prev => {
-      const current = prev[key]
-      if (current && current.min === nextMin && current.max === nextMax) {
-        return prev
-      }
-      return { ...prev, [key]: { min: nextMin, max: nextMax } }
-    })
-  }, [activeFilterMenu, baselineAggregations, rangeSelections])
-
-  useEffect(() => {
-    countByInitialized.current = false
-    setCountBySelections({})
-    setCountByReady(false)
-    chartOverridesInitialized.current = false
-    setChartCountOverrides({})
-    setActiveCountMenuKey(null)
-  }, [identifier])
-
-  useEffect(() => {
-    const storedOverrides = loadChartOverridesFromLocalStorage()
-    setChartCountOverrides(storedOverrides || {})
-    chartOverridesInitialized.current = true
-  }, [identifier])
-
-  useEffect(() => {
-    if (!chartOverridesInitialized.current) return
-    saveChartOverridesToLocalStorage(chartCountOverrides)
-  }, [chartCountOverrides, identifier])
-
-  useEffect(() => {
-    if (!activeCountMenuKey) return
-    const handleClick = () => setActiveCountMenuKey(null)
-    document.addEventListener('click', handleClick)
-    return () => document.removeEventListener('click', handleClick)
-  }, [activeCountMenuKey])
-
-  useEffect(() => {
-    if (countByInitialized.current) return
-
-    const hash = location.hash
-    const match = hash.match(/countBy=([^&]+)/)
-    const encodedCountBy = match ? match[1] : null
-
-    if (encodedCountBy) {
-      const restored = deserializeCountBySelections(encodedCountBy)
-      if (restored) {
-        setCountBySelections(restored)
-        countByInitialized.current = true
-        setCountByReady(true)
-        return
-      }
-    }
-
-    const local = loadCountByFromLocalStorage()
-    if (local) {
-      setCountBySelections(local)
-    } else {
-      setCountBySelections({})
-    }
-    countByInitialized.current = true
-    setCountByReady(true)
-  }, [identifier, location.hash])
-
-  const handleCustomRangeChange = (
-    key: string,
-    field: 'min' | 'max',
-    value: string
-  ) => {
-    setCustomRangeInputs(prev => ({
-      ...prev,
-      [key]: {
-        min: field === 'min' ? value : prev[key]?.min ?? '',
-        max: field === 'max' ? value : prev[key]?.max ?? ''
-      }
-    }))
-  }
-
-  const applyCustomRange = (tableName: string, columnName: string, countKey?: string) => {
-    const key = rangeKey(tableName, columnName, countKey)
-    const range = customRangeInputs[key]
-    if (!range) return
-
-    const min = range.min.trim()
-    const max = range.max.trim()
-    if (min === '' || max === '') return
-
-    const minValue = Number(min)
-    const maxValue = Number(max)
-    if (!Number.isFinite(minValue) || !Number.isFinite(maxValue) || minValue > maxValue) {
-      return
-    }
-
-    setCustomRangeInputs(prev => ({
-      ...prev,
-      [key]: { min: String(minValue), max: String(maxValue) }
-    }))
-
-    updateColumnRanges(tableName, columnName, prevRanges => {
-      const nextRange = { start: minValue, end: maxValue }
-      const existingIndex = prevRanges.findIndex(range => rangesEqual(range, nextRange))
-      if (existingIndex >= 0) return prevRanges
-      return [...prevRanges, nextRange]
-    }, countKey)
-  }
-
-  const getNiceBinWidth = (range: number, desiredBins: number): number => {
-    if (!Number.isFinite(range) || range <= 0) {
-      return 1
-    }
-
-    const target = range / Math.max(desiredBins, 1)
-    if (!Number.isFinite(target) || target <= 0) {
-      return range
-    }
-
-    const exponent = Math.floor(Math.log10(target))
-    const scaled = target / Math.pow(10, exponent)
-
-    let niceScaled: number
-    if (scaled <= 1) {
-      niceScaled = 1
-    } else if (scaled <= 2) {
-      niceScaled = 2
-    } else if (scaled <= 5) {
-      niceScaled = 5
-    } else {
-      niceScaled = 10
-    }
-
-    return niceScaled * Math.pow(10, exponent)
-  }
-
-  const getDisplayHistogram = (
-    histogram: HistogramBin[] | undefined,
-    stats: NumericStats | undefined
-  ): HistogramBin[] => {
-    if (!histogram || histogram.length === 0) return []
-    if (!stats || stats.min === null || stats.max === null) return histogram
-
-    const min = stats.min
-    const max = stats.max
-    if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) return histogram
-
-    const originalTotal = histogram.reduce((sum, bin) => sum + bin.count, 0)
-    if (!Number.isFinite(originalTotal) || originalTotal === 0) return histogram
-
-    const range = max - min
-    const desiredBins = Math.min(Math.max(histogram.length, 1), 60)
-    let width = getNiceBinWidth(range, desiredBins)
-    if (!Number.isFinite(width) || width <= 0) {
-      width = range || 1
-    }
-
-    let guard = 0
-    while (range / width > 60 && guard < 10) {
-      const nextApprox = Math.ceil(range / width / 2)
-      width = getNiceBinWidth(range, Math.max(nextApprox, 1))
-      if (!Number.isFinite(width) || width <= 0) {
-        width = range || 1
-        break
-      }
-      guard += 1
-    }
-
-    const start = Math.floor(min / width) * width
-    const bucketCount = Math.max(1, Math.ceil((max - start) / width) + 1)
-    const buckets: HistogramBin[] = []
-    for (let i = 0; i < bucketCount; i++) {
-      buckets.push({
-        bin_start: start + i * width,
-        bin_end: start + (i + 1) * width,
-        count: 0,
-        percentage: 0
-      })
-    }
-
-    histogram.forEach(bin => {
-      const center = (bin.bin_start + bin.bin_end) / 2
-      let index = Math.floor((center - start) / width)
-      if (index < 0) index = 0
-      if (index >= buckets.length) index = buckets.length - 1
-      buckets[index].count += bin.count
-    })
-
-    const rebinnedTotal = buckets.reduce((sum, bucket) => sum + bucket.count, 0)
-    const denominator = rebinnedTotal > 0 ? rebinnedTotal : originalTotal
-    buckets.forEach(bucket => {
-      bucket.percentage = denominator > 0 ? (bucket.count / denominator) * 100 : 0
-    })
-
-    const filtered = buckets.filter(bucket => bucket.count > 0)
-    return filtered.length > 0 ? filtered : histogram
-  }
-
-  const toggleFilter = (column: string, value: string | number, tableName?: string, countByKey?: string) => {
-    const filterValue = normalizeFilterValue(value)
-    const resolvedCountKey = countByKey ?? ROW_COUNT_KEY
-
-    setFilters(prevFilters => {
-      const nextFilters = [...prevFilters]
-
-      const existingIndex = nextFilters.findIndex(f => {
-        const actualFilter = unwrapNot(f)
-        if (!actualFilter || actualFilter.column !== column) return false
-        return getFilterCountKey(f) === resolvedCountKey
-      })
-
-      const applyMetadata = (target: Filter, source?: Filter) => {
-        if (tableName) {
-          target.tableName = tableName
-        } else if (source?.tableName) {
-          target.tableName = source.tableName
-        }
-        target.countByKey = resolvedCountKey
-      }
-
-      if (existingIndex === -1) {
-        const newFilter: Filter = { column, operator: 'eq', value: filterValue }
-        applyMetadata(newFilter)
-        nextFilters.push(newFilter)
-        return nextFilters
-      }
-
-      const existingWrapped = nextFilters[existingIndex]
-      const isNot = !!existingWrapped.not
-      const existing = isNot && existingWrapped.not ? existingWrapped.not : existingWrapped
-
-      if (existing.operator === 'eq') {
-        const existingValue = normalizeFilterValue(existing.value as string | number)
-        if (existingValue === filterValue) {
-          nextFilters.splice(existingIndex, 1)
-          return nextFilters
-        }
-
-        const updatedFilter: Filter = {
-          column,
-          operator: 'in',
-          value: [existingValue, filterValue]
-        }
-        applyMetadata(updatedFilter, existing)
-        nextFilters[existingIndex] = isNot ? { not: updatedFilter } : updatedFilter
-        return nextFilters
-      }
-
-      if (existing.operator === 'in') {
-        const values = Array.isArray(existing.value)
-          ? existing.value.map(v => normalizeFilterValue(v as string | number))
-          : []
-        const matchIndex = values.findIndex(v => v === filterValue)
-
-        if (matchIndex >= 0) {
-          values.splice(matchIndex, 1)
-        } else {
-          values.push(filterValue)
-        }
-
-        if (values.length === 0) {
-          nextFilters.splice(existingIndex, 1)
-        } else if (values.length === 1) {
-          const updatedFilter: Filter = { column, operator: 'eq', value: values[0] }
-          applyMetadata(updatedFilter, existing)
-          nextFilters[existingIndex] = isNot ? { not: updatedFilter } : updatedFilter
-        } else {
-          const updatedFilter: Filter = { column, operator: 'in', value: values }
-          applyMetadata(updatedFilter, existing)
-          nextFilters[existingIndex] = isNot ? { not: updatedFilter } : updatedFilter
-        }
-
-        return nextFilters
-      }
-
-      const updatedFilter: Filter = { column, operator: 'eq', value: filterValue }
-      applyMetadata(updatedFilter, existing)
-      nextFilters[existingIndex] = isNot ? { not: updatedFilter } : updatedFilter
-      return nextFilters
-    })
-  }
-
-  const clearFilters = () => {
-    setFilters([])
-    setCustomRangeInputs({})
-    setRangeSelections({})
-  }
-
-  const isValueFiltered = (column: string, value: string | number, countByKey?: string): boolean => {
-    const compareValue = normalizeFilterValue(value)
-    const resolvedKey = countByKey ?? ROW_COUNT_KEY
-    return filters.some(f => {
-      const actualFilter = unwrapNot(f)
-      if (!actualFilter || actualFilter.column !== column) return false
-      if (getFilterCountKey(f) !== resolvedKey) return false
-      if (actualFilter.operator === 'eq') {
-        return normalizeFilterValue(actualFilter.value as string | number) === compareValue
-      }
-      if (actualFilter.operator === 'in' && Array.isArray(actualFilter.value)) {
-        return actualFilter.value
-          .map(v => normalizeFilterValue(v as string | number))
-          .includes(compareValue)
-      }
-      return false
-    })
-  }
-
-  const toggleRangeFilter = (tableName: string, column: string, binStart: number, binEnd: number, countKey?: string) => {
-    const range = { start: binStart, end: binEnd }
-    updateColumnRanges(tableName, column, prevRanges => {
-      const existingIndex = prevRanges.findIndex(r => rangesEqual(r, range))
-      if (existingIndex >= 0) {
-        return [...prevRanges.slice(0, existingIndex), ...prevRanges.slice(existingIndex + 1)]
-      }
-      return [...prevRanges, range]
-    }, countKey)
-  }
-
-  const isRangeFiltered = (tableName: string, column: string, binStart: number, binEnd: number, countKey?: string): boolean => {
-    const key = rangeKey(tableName, column, countKey)
-    const ranges = rangeSelections[key] ?? []
-    return ranges.some(range => rangesEqual(range, { start: binStart, end: binEnd }))
-  }
-
-  const getTableColor = (tableName: string): string => {
-    if (!dataset?.tables) return '#9E9E9E'
-
-    // Assign colors based on table index for more consistent, predictable coloring
-    const tableIndex = dataset.tables.findIndex(t => t.name === tableName)
-    const colors = ['#2196F3', '#4CAF50', '#FF9800', '#9C27B0', '#F44336', '#00BCD4', '#FFC107', '#E91E63']
-
-    return tableIndex >= 0 ? colors[tableIndex % colors.length] : '#9E9E9E'
-  }
-
-  const handleCountByChange = (tableName: string, value: string) => {
-    if (value === ROW_COUNT_KEY) {
-      setCountBySelections(prev => {
-        if (!prev[tableName]) return prev
-        const next = { ...prev }
-        delete next[tableName]
-        return next
-      })
-      return
-    }
-
-    const targetTable = value.startsWith('parent:') ? value.slice('parent:'.length) : value
-    if (!targetTable) return
-
-    setCountBySelections(prev => ({
-      ...prev,
-      [tableName]: { mode: 'parent', targetTable }
-    }))
-  }
-
-  const getCountByValueForTable = (tableName: string) => getCountByCacheKey(tableName)
+  // ── ChartContext assembly ───────────────────────────────────────
 
   const chartContextValue = {
-    getEffectiveCacheKeyForChart,
-    getAggregation,
-    getBaselineAggregation,
-    getMetricLabels,
+    getEffectiveCacheKeyForChart: countBy.getEffectiveCacheKeyForChart,
+    getAggregation: loader.getAggregation,
+    getBaselineAggregation: loader.getBaselineAggregation,
+    getMetricLabels: loader.getMetricLabels,
     metricsMatch,
-    getColumnMetadata,
-    getTableDisplayNameByName,
-    formatMetricPath,
+    getColumnMetadata: loader.getColumnMetadata,
+    getTableDisplayNameByName: loader.getTableDisplayNameByName,
+    formatMetricPath: loader.formatMetricPath,
     getCountByOptions,
-    getCountByCacheKey,
-    handleCountByChange,
+    getCountByCacheKey: countBy.getCountByCacheKey,
+    handleCountByChange: countBy.handleCountByChange,
     handleChartCountOverrideChange,
-    activeCountMenuKey,
-    setActiveCountMenuKey,
-    getTableColor,
+    activeCountMenuKey: countBy.activeCountMenuKey,
+    setActiveCountMenuKey: countBy.setActiveCountMenuKey,
+    getTableColor: loader.getTableColor,
     getCountIndicatorColor,
     getCountByTableColor,
     getCountByLabelFromCacheKey,
-    activeFilterMenu,
-    setActiveFilterMenu,
-    filters,
-    setFilters,
-    hasColumnFilter,
-    isValueFiltered,
+    activeFilterMenu: filterState.activeFilterMenu,
+    setActiveFilterMenu: filterState.setActiveFilterMenu,
+    filters: filterState.filters,
+    setFilters: filterState.setFilters,
+    hasColumnFilter: filterState.hasColumnFilter,
+    isValueFiltered: filterState.isValueFiltered,
     normalizeFilterValue,
-    toggleFilter,
-    clearColumnFilter,
-    removeColumnFilters,
-    rangeSelections,
-    customRangeInputs,
-    toggleRangeFilter,
-    isRangeFiltered,
-    handleCustomRangeChange,
-    applyCustomRange,
-    updateColumnRanges,
+    toggleFilter: filterState.toggleFilter,
+    clearColumnFilter: filterState.clearColumnFilter,
+    removeColumnFilters: filterState.removeColumnFilters,
+    rangeSelections: filterState.rangeSelections,
+    customRangeInputs: filterState.customRangeInputs,
+    toggleRangeFilter: filterState.toggleRangeFilter,
+    isRangeFiltered: filterState.isRangeFiltered,
+    handleCustomRangeChange: filterState.handleCustomRangeChange,
+    applyCustomRange: filterState.applyCustomRange,
+    updateColumnRanges: filterState.updateColumnRanges,
     formatRangeValue,
     getDisplayHistogram,
     showPercentageLabels,
     toggleViewPreference,
     getSurvivalViewPreference,
     toggleSurvivalViewPreference,
-    findTable: (tableName: string) => dataset?.tables.find(t => t.name === tableName),
-    findSurvivalStatusColumn,
-    ensureSurvivalCurve,
-    getSurvivalCurve,
+    findTable: (tableName: string) => loader.dataset?.tables.find(t => t.name === tableName),
+    findSurvivalStatusColumn: loader.findSurvivalStatusColumn,
+    ensureSurvivalCurve: loader.ensureSurvivalCurve,
+    getSurvivalCurve: loader.getSurvivalCurve,
     isOnDashboard,
     toggleDashboard,
   }
 
-  if (loading) return <p>Loading explorer...</p>
-  if (error) return <div role="alert" style={{ padding: '2rem', color: 'red' }}>Error: {error}</div>
-  if (!dataset) return <p>Dataset not found</p>
+  // ── Render ──────────────────────────────────────────────────────
+
+  if (loader.loading) return <p>Loading explorer...</p>
+  if (loader.error) return <div role="alert" style={{ padding: '2rem', color: 'red' }}>Error: {loader.error}</div>
+  if (!loader.dataset) return <p>Dataset not found</p>
 
   return (
     <ChartProvider value={chartContextValue}>
     <div>
       {/* Header */}
       <DatasetHeader
-        name={dataset.name}
-        description={dataset.description}
-        tableCount={dataset.tables.length}
+        name={loader.dataset.name}
+        description={loader.dataset.description}
+        tableCount={loader.dataset.tables.length}
         onManage={() => navigate(`/datasets/${id}/manage`)}
       />
 
@@ -1756,16 +455,16 @@ function DatasetExplorer() {
       />
 
       <ActiveFilters
-        filters={filters}
-        setFilters={setFilters}
+        filters={filterState.filters}
+        setFilters={filterState.setFilters}
         onSaveFilter={() => setShowSavePresetDialog(true)}
-        onClearFilters={clearFilters}
-        getTableColor={getTableColor}
-        getFilterTableNameForCacheKey={getFilterTableNameForCacheKey}
+        onClearFilters={filterState.clearFilters}
+        getTableColor={loader.getTableColor}
+        getFilterTableNameForCacheKey={filterState.getFilterTableNameForCacheKey}
         targetFromCacheKey={targetFromCacheKey}
         formatRangeValue={formatRangeValue}
-        clearColumnFilter={clearColumnFilter}
-        datasetTables={dataset?.tables}
+        clearColumnFilter={filterState.clearColumnFilter}
+        datasetTables={loader.dataset?.tables}
       />
 
       <PresetDialogs
@@ -1788,7 +487,6 @@ function DatasetExplorer() {
         importPresets={importPresets}
       />
 
-
       <DashboardDialogs
         savedDashboards={savedDashboards}
         activeDashboardId={activeDashboardId}
@@ -1810,12 +508,12 @@ function DatasetExplorer() {
       />
 
       <TabBar
-        tables={dataset.tables}
+        tables={loader.dataset.tables}
         activeTab={activeTab}
         onTabChange={setActiveTab}
         dashboardChartCount={dashboardCharts.length}
-        getTableColor={getTableColor}
-        getTableChartCount={getTableChartCount}
+        getTableColor={loader.getTableColor}
+        getTableChartCount={loader.getTableChartCount}
       />
 
       {/* Dashboard View */}
@@ -1831,10 +529,10 @@ function DatasetExplorer() {
           setShowManageDashboardsDialog={setShowManageDashboardsDialog}
           getDashboardChartKey={getDashboardChartKey}
           registerDashboardCard={registerDashboardCard}
-          getAggregation={getAggregation}
-          getTableColor={getTableColor}
-          getDisplayTitle={getDisplayTitle}
-          getColumnMetadata={getColumnMetadata}
+          getAggregation={loader.getAggregation}
+          getTableColor={loader.getTableColor}
+          getDisplayTitle={loader.getDisplayTitle}
+          getColumnMetadata={loader.getColumnMetadata}
           getViewPreference={getViewPreference}
           getSurvivalViewPreference={getSurvivalViewPreference}
           toggleSurvivalViewPreference={toggleSurvivalViewPreference}
@@ -1843,15 +541,15 @@ function DatasetExplorer() {
       )}
 
       {/* Chart Grid - Grouped by Table */}
-      {dataset.tables
+      {loader.dataset.tables
         .filter(table => table.name === activeTab)
         .map(table => {
-          const tableAggregations = getAggregationsForTable(table.name)
+          const tableAggregations = loader.getAggregationsForTable(table.name)
           if (!tableAggregations) return null
 
           const sortedAggregations = [...tableAggregations].sort((a, b) => {
-            const metaA = getColumnMetadata(table.name, a.column_name)
-            const metaB = getColumnMetadata(table.name, b.column_name)
+            const metaA = loader.getColumnMetadata(table.name, a.column_name)
+            const metaB = loader.getColumnMetadata(table.name, b.column_name)
             const priorityA = metaA?.display_priority || 0
             const priorityB = metaB?.display_priority || 0
             return priorityB - priorityA
@@ -1859,40 +557,40 @@ function DatasetExplorer() {
 
           // Filter out hidden columns
           const visibleAggregations = sortedAggregations.filter(agg => {
-            const metadata = getColumnMetadata(table.name, agg.column_name)
+            const metadata = loader.getColumnMetadata(table.name, agg.column_name)
             return !metadata?.is_hidden
           })
 
           if (visibleAggregations.length === 0) return null
 
-          const tableColor = getTableColor(table.name)
+          const tableColor = loader.getTableColor(table.name)
           const primaryAggregation = visibleAggregations[0]
-          const tableRowCount = primaryAggregation?.total_rows ?? table.rowCount ?? 0
 
           // Get baseline (unfiltered) row count for this table
-          const baselineTableAggs = baselineAggregations[table.name] || []
+          const baselineTableAggs = loader.baselineAggregations[table.name] || []
           const baselineSample = baselineTableAggs.length > 0 ? baselineTableAggs[0] : undefined
           const baselineMatches = metricsMatch(baselineSample, primaryAggregation)
+          const tableRowCount = primaryAggregation?.total_rows ?? table.rowCount ?? 0
           const baselineRowCount = baselineMatches
             ? baselineSample?.total_rows ?? tableRowCount
             : null
 
           // Get filter counts for this table
-          const effectiveFilters = getAllEffectiveFilters()
+          const effectiveFilters = loader.getAllEffectiveFilters()
           const tableFilters = effectiveFilters[table.name] || { direct: [], propagated: [] }
           const directFilterCount = tableFilters.direct.length
           const propagatedFilterCount = tableFilters.propagated.length
           const hasTableFilters = directFilterCount > 0 || propagatedFilterCount > 0
 
-          const metricLabels = getMetricLabels(primaryAggregation)
-          const parentOptions = ancestorOptions[table.name] || []
-          const countByValue = getCountByValueForTable(table.name)
+          const metricLabels = loader.getMetricLabels(primaryAggregation)
+          const parentOptions = loader.ancestorOptions[table.name] || []
+          const countByValue = countBy.getCountByValueForTable(table.name)
 
           return (
             <TableSection
               key={table.name}
               table={table}
-              tables={dataset.tables}
+              tables={loader.dataset!.tables}
               tableColor={tableColor}
               visibleAggregations={visibleAggregations}
               primaryAggregation={primaryAggregation}
@@ -1904,11 +602,11 @@ function DatasetExplorer() {
               metricLabels={metricLabels}
               countByValue={countByValue}
               parentOptions={parentOptions}
-              getTableColor={getTableColor}
-              getDisplayTitle={getDisplayTitle}
-              getColumnMetadata={getColumnMetadata}
-              getEffectiveCacheKeyForChart={getEffectiveCacheKeyForChart}
-              getCountByCacheKey={getCountByCacheKey}
+              getTableColor={loader.getTableColor}
+              getDisplayTitle={loader.getDisplayTitle}
+              getColumnMetadata={loader.getColumnMetadata}
+              getEffectiveCacheKeyForChart={countBy.getEffectiveCacheKeyForChart}
+              getCountByCacheKey={countBy.getCountByCacheKey}
               getCountByLabelFromCacheKey={getCountByLabelFromCacheKey}
               getViewPreference={getViewPreference}
               getSurvivalViewPreference={getSurvivalViewPreference}

--- a/client/src/pages/DatasetExplorer/__tests__/utils.test.ts
+++ b/client/src/pages/DatasetExplorer/__tests__/utils.test.ts
@@ -1,0 +1,271 @@
+import { describe, test, expect } from 'vitest'
+import {
+  chartKey,
+  targetFromCacheKey,
+  parseSelectionFromCacheKey,
+  normalizeFilterValue,
+  formatRangeValue,
+  buildFiltersKey,
+  metricsMatch,
+  serializeFilters,
+  deserializeFilters,
+  serializeCountBySelections,
+  deserializeCountBySelections,
+  buildAncestorOptions,
+  normalizeCountBySelections,
+  getNiceBinWidth,
+  getDisplayHistogram,
+} from '../utils'
+import type { ColumnAggregation, Table } from '../types'
+
+describe('utils', () => {
+  describe('chartKey', () => {
+    test('combines table and column names', () => {
+      expect(chartKey('patients', 'age')).toBe('patients.age')
+    })
+  })
+
+  describe('targetFromCacheKey', () => {
+    test('returns null for undefined', () => {
+      expect(targetFromCacheKey(undefined)).toBeNull()
+    })
+
+    test('returns null for non-parent key', () => {
+      expect(targetFromCacheKey('rows')).toBeNull()
+    })
+
+    test('extracts target from parent key', () => {
+      expect(targetFromCacheKey('parent:patients')).toBe('patients')
+    })
+  })
+
+  describe('parseSelectionFromCacheKey', () => {
+    test('returns null for undefined', () => {
+      expect(parseSelectionFromCacheKey(undefined)).toBeNull()
+    })
+
+    test('returns null for non-parent key', () => {
+      expect(parseSelectionFromCacheKey('rows')).toBeNull()
+    })
+
+    test('parses parent key', () => {
+      expect(parseSelectionFromCacheKey('parent:patients')).toEqual({
+        mode: 'parent',
+        targetTable: 'patients',
+      })
+    })
+  })
+
+  describe('normalizeFilterValue', () => {
+    test('returns empty string for null', () => {
+      expect(normalizeFilterValue(null)).toBe('')
+    })
+
+    test('returns empty string for undefined', () => {
+      expect(normalizeFilterValue(undefined)).toBe('')
+    })
+
+    test('converts number to string', () => {
+      expect(normalizeFilterValue(42)).toBe('42')
+    })
+
+    test('passes through strings', () => {
+      expect(normalizeFilterValue('hello')).toBe('hello')
+    })
+  })
+
+  describe('formatRangeValue', () => {
+    test('formats integers without decimals', () => {
+      expect(formatRangeValue(42)).toBe('42')
+    })
+
+    test('formats floats to 2 decimal places', () => {
+      expect(formatRangeValue(3.14159)).toBe('3.14')
+    })
+
+    test('returns dash for non-finite values', () => {
+      expect(formatRangeValue(Infinity)).toBe('–')
+      expect(formatRangeValue(NaN)).toBe('–')
+    })
+  })
+
+  describe('buildFiltersKey', () => {
+    test('returns empty array JSON for undefined', () => {
+      expect(buildFiltersKey()).toBe('[]')
+    })
+
+    test('serializes filters to JSON', () => {
+      const filters = [{ column: 'age', operator: 'eq', value: '30' }]
+      expect(buildFiltersKey(filters as any)).toBe(JSON.stringify(filters))
+    })
+  })
+
+  describe('metricsMatch', () => {
+    test('returns false if either is undefined', () => {
+      expect(metricsMatch(undefined, {} as any)).toBe(false)
+      expect(metricsMatch({} as any, undefined)).toBe(false)
+    })
+
+    test('matches two row-type aggregations', () => {
+      const a = { metric_type: 'rows' } as ColumnAggregation
+      const b = {} as ColumnAggregation // defaults to 'rows'
+      expect(metricsMatch(a, b)).toBe(true)
+    })
+
+    test('does not match different metric types', () => {
+      const a = { metric_type: 'rows' } as ColumnAggregation
+      const b = { metric_type: 'parent', metric_parent_table: 'x' } as ColumnAggregation
+      expect(metricsMatch(a, b)).toBe(false)
+    })
+
+    test('matches parent aggregations with same table and path', () => {
+      const path = [{ from_table: 'visits', via_column: 'patient_id', to_table: 'patients' }]
+      const a = { metric_type: 'parent', metric_parent_table: 'patients', metric_path: path } as ColumnAggregation
+      const b = { metric_type: 'parent', metric_parent_table: 'patients', metric_path: path } as ColumnAggregation
+      expect(metricsMatch(a, b)).toBe(true)
+    })
+
+    test('does not match parent aggregations with different parent tables', () => {
+      const a = { metric_type: 'parent', metric_parent_table: 'patients' } as ColumnAggregation
+      const b = { metric_type: 'parent', metric_parent_table: 'visits' } as ColumnAggregation
+      expect(metricsMatch(a, b)).toBe(false)
+    })
+  })
+
+  describe('serializeFilters / deserializeFilters', () => {
+    test('round-trips filters', () => {
+      const filters = [{ column: 'age', operator: 'eq', value: '30' }]
+      const encoded = serializeFilters(filters as any)
+      const decoded = deserializeFilters(encoded)
+      expect(decoded).toEqual(filters)
+    })
+  })
+
+  describe('serializeCountBySelections / deserializeCountBySelections', () => {
+    test('round-trips selections', () => {
+      const selections = { patients: { mode: 'parent' as const, targetTable: 'visits' } }
+      const encoded = serializeCountBySelections(selections)
+      const decoded = deserializeCountBySelections(encoded)
+      expect(decoded).toEqual(selections)
+    })
+  })
+
+  describe('buildAncestorOptions', () => {
+    test('returns empty for tables with no relationships', () => {
+      const tables: Table[] = [
+        { id: '1', name: 'patients', rowCount: 100, relationships: [] }
+      ] as any
+      const result = buildAncestorOptions(tables)
+      expect(result.patients).toEqual([])
+    })
+
+    test('finds direct parent relationships', () => {
+      const tables: Table[] = [
+        {
+          id: '1', name: 'visits', rowCount: 200,
+          relationships: [{ foreign_key: 'patient_id', referenced_table: 'patients' }]
+        },
+        {
+          id: '2', name: 'patients', rowCount: 100,
+          relationships: []
+        }
+      ] as any
+      const result = buildAncestorOptions(tables)
+      expect(result.visits).toHaveLength(1)
+      expect(result.visits[0].targetTable).toBe('patients')
+      expect(result.visits[0].key).toBe('parent:patients')
+    })
+
+    test('returns empty for the root table with no parents', () => {
+      const tables: Table[] = [
+        {
+          id: '1', name: 'visits', rowCount: 200,
+          relationships: [{ foreign_key: 'patient_id', referenced_table: 'patients' }]
+        },
+        {
+          id: '2', name: 'patients', rowCount: 100,
+          relationships: []
+        }
+      ] as any
+      const result = buildAncestorOptions(tables)
+      expect(result.patients).toEqual([])
+    })
+  })
+
+  describe('normalizeCountBySelections', () => {
+    test('keeps valid selections', () => {
+      const selections = { visits: { mode: 'parent' as const, targetTable: 'patients' } }
+      const options = { visits: [{ targetTable: 'patients', label: 'Patients', key: 'parent:patients', path: [] }] }
+      expect(normalizeCountBySelections(selections, options)).toBe(selections)
+    })
+
+    test('removes invalid selections', () => {
+      const selections = { visits: { mode: 'parent' as const, targetTable: 'nonexistent' } }
+      const options = { visits: [{ targetTable: 'patients', label: 'Patients', key: 'parent:patients', path: [] }] }
+      const result = normalizeCountBySelections(selections, options)
+      expect(result).toEqual({})
+    })
+
+    test('removes selections for tables with no options', () => {
+      const selections = { visits: { mode: 'parent' as const, targetTable: 'patients' } }
+      const options = { visits: [] }
+      const result = normalizeCountBySelections(selections, options as any)
+      expect(result).toEqual({})
+    })
+  })
+
+  describe('getNiceBinWidth', () => {
+    test('returns 1 for zero range', () => {
+      expect(getNiceBinWidth(0, 10)).toBe(1)
+    })
+
+    test('returns 1 for negative range', () => {
+      expect(getNiceBinWidth(-5, 10)).toBe(1)
+    })
+
+    test('returns nice bin width for typical range', () => {
+      const width = getNiceBinWidth(100, 10)
+      expect([1, 2, 5, 10, 20, 50, 100]).toContain(width)
+    })
+
+    test('returns nice bin width for large range', () => {
+      const width = getNiceBinWidth(10000, 20)
+      expect(width).toBeGreaterThan(0)
+      expect(Number.isFinite(width)).toBe(true)
+    })
+  })
+
+  describe('getDisplayHistogram', () => {
+    test('returns empty array for empty histogram', () => {
+      expect(getDisplayHistogram([], undefined)).toEqual([])
+      expect(getDisplayHistogram(undefined, undefined)).toEqual([])
+    })
+
+    test('returns original histogram when stats are missing', () => {
+      const histogram = [{ bin_start: 0, bin_end: 10, count: 5, percentage: 100 }]
+      expect(getDisplayHistogram(histogram, undefined)).toBe(histogram)
+    })
+
+    test('returns original histogram when range is zero', () => {
+      const histogram = [{ bin_start: 5, bin_end: 5, count: 10, percentage: 100 }]
+      const stats = { min: 5, max: 5, mean: 5, stddev: 0, median: 5, q25: 5, q75: 5 }
+      expect(getDisplayHistogram(histogram, stats)).toBe(histogram)
+    })
+
+    test('rebins histogram with nice bin widths', () => {
+      const histogram = [
+        { bin_start: 0, bin_end: 3, count: 10, percentage: 33.3 },
+        { bin_start: 3, bin_end: 7, count: 15, percentage: 50 },
+        { bin_start: 7, bin_end: 10, count: 5, percentage: 16.7 },
+      ]
+      const stats = { min: 0, max: 10, mean: 5, stddev: 3, median: 5, q25: 2, q75: 8 }
+      const result = getDisplayHistogram(histogram, stats)
+      expect(result.length).toBeGreaterThan(0)
+      // All bins should have count > 0 (filtered)
+      result.forEach(bin => expect(bin.count).toBeGreaterThan(0))
+      // Percentages should sum to approximately 100
+      const totalPercentage = result.reduce((sum, bin) => sum + bin.percentage, 0)
+      expect(totalPercentage).toBeCloseTo(100, 0)
+    })
+  })
+})

--- a/client/src/pages/DatasetExplorer/hooks/__tests__/useCountBy.test.ts
+++ b/client/src/pages/DatasetExplorer/hooks/__tests__/useCountBy.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useCountBy } from '../useCountBy'
+
+describe('useCountBy', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+  })
+
+  test('initializes with empty state', () => {
+    const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+    expect(result.current.countBySelections).toEqual({})
+    expect(result.current.chartCountOverrides).toEqual({})
+    expect(result.current.activeCountMenuKey).toBeNull()
+    expect(result.current.countByReady).toBe(true) // becomes true after init
+  })
+
+  describe('getCountByCacheKey', () => {
+    test('returns override when provided', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+      expect(result.current.getCountByCacheKey('patients', 'parent:visits')).toBe('parent:visits')
+    })
+
+    test('returns rows key when no selection', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+      expect(result.current.getCountByCacheKey('patients')).toBe('rows')
+    })
+
+    test('returns parent key when selection exists', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.handleCountByChange('patients', 'parent:visits')
+      })
+
+      expect(result.current.getCountByCacheKey('patients')).toBe('parent:visits')
+    })
+  })
+
+  describe('handleCountByChange', () => {
+    test('sets parent selection', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.handleCountByChange('patients', 'parent:visits')
+      })
+
+      expect(result.current.countBySelections.patients).toEqual({
+        mode: 'parent',
+        targetTable: 'visits'
+      })
+    })
+
+    test('clears selection on rows key', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.handleCountByChange('patients', 'parent:visits')
+      })
+      expect(result.current.countBySelections.patients).toBeDefined()
+
+      act(() => {
+        result.current.handleCountByChange('patients', 'rows')
+      })
+      expect(result.current.countBySelections.patients).toBeUndefined()
+    })
+  })
+
+  describe('getEffectiveCacheKeyForChart', () => {
+    test('returns table default when no chart override', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+      expect(result.current.getEffectiveCacheKeyForChart('patients', 'age')).toBe('rows')
+    })
+
+    test('returns chart override when set', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.setChartOverrideForChart('patients', 'age', 'parent:visits')
+      })
+
+      expect(result.current.getEffectiveCacheKeyForChart('patients', 'age')).toBe('parent:visits')
+    })
+  })
+
+  describe('setChartOverrideForChart', () => {
+    test('sets override', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.setChartOverrideForChart('patients', 'age', 'parent:visits')
+      })
+
+      expect(result.current.chartCountOverrides['patients.age']).toBe('parent:visits')
+    })
+
+    test('clears override when undefined', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.setChartOverrideForChart('patients', 'age', 'parent:visits')
+      })
+      expect(result.current.chartCountOverrides['patients.age']).toBe('parent:visits')
+
+      act(() => {
+        result.current.setChartOverrideForChart('patients', 'age')
+      })
+      expect(result.current.chartCountOverrides['patients.age']).toBeUndefined()
+    })
+
+    test('clears override when value matches default', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.setChartOverrideForChart('patients', 'age', 'parent:visits')
+      })
+
+      act(() => {
+        result.current.setChartOverrideForChart('patients', 'age', 'rows')
+      })
+      expect(result.current.chartCountOverrides['patients.age']).toBeUndefined()
+    })
+  })
+
+  describe('getCountByValueForTable', () => {
+    test('returns same as getCountByCacheKey', () => {
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+      expect(result.current.getCountByValueForTable('patients')).toBe(
+        result.current.getCountByCacheKey('patients')
+      )
+    })
+  })
+
+  describe('chart overrides persistence', () => {
+    test('loads overrides from localStorage on init', () => {
+      localStorage.setItem('chartOverrides_test-dataset', JSON.stringify({ 'patients.age': 'parent:visits' }))
+
+      const { result } = renderHook(() => useCountBy({ identifier: 'test-dataset' }))
+      expect(result.current.chartCountOverrides['patients.age']).toBe('parent:visits')
+    })
+  })
+
+  describe('identifier change', () => {
+    test('resets state when identifier changes', () => {
+      const { result, rerender } = renderHook(
+        ({ identifier }) => useCountBy({ identifier }),
+        { initialProps: { identifier: 'dataset-1' } }
+      )
+
+      act(() => {
+        result.current.handleCountByChange('patients', 'parent:visits')
+      })
+      expect(result.current.countBySelections.patients).toBeDefined()
+
+      rerender({ identifier: 'dataset-2' })
+
+      expect(result.current.countBySelections).toEqual({})
+    })
+  })
+})

--- a/client/src/pages/DatasetExplorer/hooks/__tests__/useFilterState.test.ts
+++ b/client/src/pages/DatasetExplorer/hooks/__tests__/useFilterState.test.ts
@@ -1,0 +1,227 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useFilterState } from '../useFilterState'
+
+describe('useFilterState', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+  })
+
+  test('initializes with empty filters', () => {
+    const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+    expect(result.current.filters).toEqual([])
+    expect(result.current.activeFilterMenu).toBeNull()
+    expect(result.current.customRangeInputs).toEqual({})
+    expect(result.current.rangeSelections).toEqual({})
+  })
+
+  test('restores filters from localStorage', () => {
+    const storedFilters = [{ column: 'age', operator: 'eq', value: '30', tableName: 'patients' }]
+    localStorage.setItem('filters_test-dataset', JSON.stringify(storedFilters))
+
+    const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+    expect(result.current.filters).toHaveLength(1)
+    expect(result.current.filters[0].column).toBe('age')
+    expect(result.current.filters[0].operator).toBe('eq')
+    expect(result.current.filters[0].value).toBe('30')
+    expect(result.current.filters[0].tableName).toBe('patients')
+  })
+
+  describe('toggleFilter', () => {
+    test('adds a new filter', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+
+      expect(result.current.filters).toHaveLength(1)
+      expect(result.current.filters[0].column).toBe('age')
+      expect(result.current.filters[0].operator).toBe('eq')
+      expect(result.current.filters[0].value).toBe('30')
+    })
+
+    test('removes existing eq filter when toggled again', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+      expect(result.current.filters).toHaveLength(1)
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+      expect(result.current.filters).toHaveLength(0)
+    })
+
+    test('upgrades eq to in when adding second value', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+      act(() => {
+        result.current.toggleFilter('age', '40', 'patients')
+      })
+
+      expect(result.current.filters).toHaveLength(1)
+      expect(result.current.filters[0].operator).toBe('in')
+      expect(result.current.filters[0].value).toEqual(['30', '40'])
+    })
+
+    test('removes value from in filter', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+      act(() => {
+        result.current.toggleFilter('age', '40', 'patients')
+      })
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+
+      expect(result.current.filters).toHaveLength(1)
+      expect(result.current.filters[0].operator).toBe('eq')
+      expect(result.current.filters[0].value).toBe('40')
+    })
+  })
+
+  describe('clearFilters', () => {
+    test('clears all filters and range state', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+      expect(result.current.filters).toHaveLength(1)
+
+      act(() => {
+        result.current.clearFilters()
+      })
+
+      expect(result.current.filters).toEqual([])
+      expect(result.current.customRangeInputs).toEqual({})
+      expect(result.current.rangeSelections).toEqual({})
+    })
+  })
+
+  describe('isValueFiltered', () => {
+    test('returns true for filtered value', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+
+      expect(result.current.isValueFiltered('age', '30')).toBe(true)
+      expect(result.current.isValueFiltered('age', '40')).toBe(false)
+    })
+
+    test('returns true for value in in-filter', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+      act(() => {
+        result.current.toggleFilter('age', '40', 'patients')
+      })
+
+      expect(result.current.isValueFiltered('age', '30')).toBe(true)
+      expect(result.current.isValueFiltered('age', '40')).toBe(true)
+      expect(result.current.isValueFiltered('age', '50')).toBe(false)
+    })
+  })
+
+  describe('hasColumnFilter', () => {
+    test('returns true when column has a filter', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+
+      expect(result.current.hasColumnFilter('age')).toBe(true)
+      expect(result.current.hasColumnFilter('name')).toBe(false)
+    })
+  })
+
+  describe('clearColumnFilter', () => {
+    test('removes all filters for a specific column', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+      act(() => {
+        result.current.toggleFilter('name', 'John', 'patients')
+      })
+      expect(result.current.filters).toHaveLength(2)
+
+      act(() => {
+        result.current.clearColumnFilter('patients', 'age')
+      })
+
+      expect(result.current.filters).toHaveLength(1)
+      expect(result.current.filters[0].column).toBe('name')
+    })
+  })
+
+  describe('handleCustomRangeChange', () => {
+    test('updates min value', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.handleCustomRangeChange('patients|age|rows', 'min', '10')
+      })
+
+      expect(result.current.customRangeInputs['patients|age|rows']).toEqual({
+        min: '10',
+        max: ''
+      })
+    })
+
+    test('updates max value', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+
+      act(() => {
+        result.current.handleCustomRangeChange('patients|age|rows', 'max', '90')
+      })
+
+      expect(result.current.customRangeInputs['patients|age|rows']).toEqual({
+        min: '',
+        max: '90'
+      })
+    })
+  })
+
+  describe('saveFiltersToLocalStorage', () => {
+    test('persists filters to localStorage', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+      const filters = [{ column: 'age', operator: 'eq', value: '30' }]
+
+      act(() => {
+        result.current.saveFiltersToLocalStorage(filters as any)
+      })
+
+      expect(localStorage.getItem('filters_test-dataset')).toBe(JSON.stringify(filters))
+    })
+  })
+
+  describe('currentFiltersKey', () => {
+    test('changes when filters change', () => {
+      const { result } = renderHook(() => useFilterState({ identifier: 'test-dataset' }))
+      const initialKey = result.current.currentFiltersKey
+
+      act(() => {
+        result.current.toggleFilter('age', '30', 'patients')
+      })
+
+      expect(result.current.currentFiltersKey).not.toBe(initialKey)
+    })
+  })
+})

--- a/client/src/pages/DatasetExplorer/hooks/useCountBy.ts
+++ b/client/src/pages/DatasetExplorer/hooks/useCountBy.ts
@@ -1,0 +1,161 @@
+import { useState, useEffect, useRef } from 'react'
+import { ROW_COUNT_KEY } from '../../../utils/filterHelpers'
+import type { CountBySelection } from '../../../utils/presetHelpers'
+import { chartKey, deserializeCountBySelections } from '../utils'
+import { persistChartOverrides, loadChartOverrides } from '../types'
+
+interface UseCountByArgs {
+  identifier: string | undefined
+}
+
+export function useCountBy({ identifier }: UseCountByArgs) {
+  const [countBySelections, setCountBySelections] = useState<Record<string, CountBySelection>>({})
+  const [countByReady, setCountByReady] = useState(false)
+  const [chartCountOverrides, setChartCountOverrides] = useState<Record<string, string>>({})
+  const [activeCountMenuKey, setActiveCountMenuKey] = useState<string | null>(null)
+
+  const countByInitialized = useRef(false)
+  const previousCountByRef = useRef<Record<string, CountBySelection>>({})
+  const chartOverridesInitialized = useRef(false)
+
+  // Reset on identifier change
+  useEffect(() => {
+    countByInitialized.current = false
+    setCountBySelections({})
+    setCountByReady(false)
+    chartOverridesInitialized.current = false
+    setChartCountOverrides({})
+    setActiveCountMenuKey(null)
+  }, [identifier])
+
+  // Load chart overrides from localStorage
+  useEffect(() => {
+    if (!identifier) return
+    try {
+      const stored = loadChartOverrides(localStorage, identifier)
+      setChartCountOverrides(stored || {})
+    } catch (error) {
+      console.error('Failed to load chart overrides:', error)
+    }
+    chartOverridesInitialized.current = true
+  }, [identifier])
+
+  // Persist chart overrides
+  useEffect(() => {
+    if (!chartOverridesInitialized.current || !identifier) return
+    try {
+      persistChartOverrides(localStorage, identifier, chartCountOverrides)
+    } catch (error) {
+      console.error('Failed to persist chart overrides:', error)
+    }
+  }, [chartCountOverrides, identifier])
+
+  // Close count menu on outside click
+  useEffect(() => {
+    if (!activeCountMenuKey) return
+    const handleClick = () => setActiveCountMenuKey(null)
+    document.addEventListener('click', handleClick)
+    return () => document.removeEventListener('click', handleClick)
+  }, [activeCountMenuKey])
+
+  // Init countBy from URL hash / localStorage
+  useEffect(() => {
+    if (countByInitialized.current) return
+
+    const hash = window.location.hash
+    const match = hash.match(/countBy=([^&]+)/)
+    const encodedCountBy = match ? match[1] : null
+
+    if (encodedCountBy) {
+      const restored = deserializeCountBySelections(encodedCountBy)
+      if (restored) {
+        setCountBySelections(restored)
+        countByInitialized.current = true
+        setCountByReady(true)
+        return
+      }
+    }
+
+    try {
+      const stored = localStorage.getItem(`countBy_${identifier}`)
+      if (stored) {
+        setCountBySelections(JSON.parse(stored))
+      } else {
+        setCountBySelections({})
+      }
+    } catch (error) {
+      console.error('Failed to load countBy from localStorage:', error)
+      setCountBySelections({})
+    }
+    countByInitialized.current = true
+    setCountByReady(true)
+  }, [identifier])
+
+  // ── CountBy functions ─────────────────────────────────────────────
+
+  const getCountByCacheKey = (tableName: string, override?: string): string => {
+    if (override) return override
+    const selection = countBySelections[tableName]
+    return selection ? `parent:${selection.targetTable}` : ROW_COUNT_KEY
+  }
+
+  const getChartOverrideKey = (tableName: string, columnName: string): string | undefined =>
+    chartCountOverrides[chartKey(tableName, columnName)]
+
+  const getEffectiveCacheKeyForChart = (tableName: string, columnName: string): string => {
+    const override = getChartOverrideKey(tableName, columnName)
+    return override ?? getCountByCacheKey(tableName)
+  }
+
+  const setChartOverrideForChart = (tableName: string, columnName: string, override?: string) => {
+    setChartCountOverrides(prev => {
+      const key = chartKey(tableName, columnName)
+      const defaultKey = getCountByCacheKey(tableName)
+      if (!override || override === defaultKey) {
+        if (!(key in prev)) return prev
+        const { [key]: _removed, ...rest } = prev
+        return rest
+      }
+      if (prev[key] === override) return prev
+      return { ...prev, [key]: override }
+    })
+  }
+
+  const handleCountByChange = (tableName: string, value: string) => {
+    if (value === ROW_COUNT_KEY) {
+      setCountBySelections(prev => {
+        if (!prev[tableName]) return prev
+        const next = { ...prev }
+        delete next[tableName]
+        return next
+      })
+      return
+    }
+
+    const targetTable = value.startsWith('parent:') ? value.slice('parent:'.length) : value
+    if (!targetTable) return
+
+    setCountBySelections(prev => ({
+      ...prev,
+      [tableName]: { mode: 'parent', targetTable }
+    }))
+  }
+
+  const getCountByValueForTable = (tableName: string) => getCountByCacheKey(tableName)
+
+  return {
+    countBySelections,
+    setCountBySelections,
+    countByReady,
+    chartCountOverrides,
+    activeCountMenuKey,
+    setActiveCountMenuKey,
+    countByInitialized,
+    previousCountByRef,
+    getCountByCacheKey,
+    getEffectiveCacheKeyForChart,
+    setChartOverrideForChart,
+    handleCountByChange,
+    getCountByValueForTable,
+  }
+}

--- a/client/src/pages/DatasetExplorer/hooks/useDatasetLoader.ts
+++ b/client/src/pages/DatasetExplorer/hooks/useDatasetLoader.ts
@@ -1,0 +1,577 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import api from '../../../services/api'
+import { type Filter, ROW_COUNT_KEY, findRelationshipPath } from '../../../utils/filterHelpers'
+import type { CountBySelection } from '../../../utils/presetHelpers'
+import type { DashboardChart } from './useDashboard'
+import {
+  buildFiltersKey,
+  buildAncestorOptions,
+} from '../utils'
+import {
+  CACHE_TTL_MS,
+  CACHE_MAX_ENTRIES_PER_TABLE,
+  type ColumnMetadata,
+  type ColumnAggregation,
+  type SurvivalCurvePoint,
+  type Table,
+  type Dataset,
+  type AncestorOption,
+  type AggregationCacheEntry,
+  type SurvivalCacheEntry,
+} from '../types'
+
+interface UseDatasetLoaderArgs {
+  id: string | undefined
+  database: string | undefined
+  identifier: string | undefined
+  isDatabaseMode: boolean
+  filters: Filter[]
+  currentFiltersKey: string
+  countBySelections: Record<string, CountBySelection>
+  countByReady: boolean
+  getCountByCacheKey: (tableName: string, override?: string) => string
+  chartCountOverrides: Record<string, string>
+  dashboardCharts: DashboardChart[]
+  getDashboardChartKey: (chart: DashboardChart) => string
+  visibleDashboardKeys: Record<string, boolean>
+  previousCountByRef: React.MutableRefObject<Record<string, CountBySelection>>
+  onDatasetLoaded: () => void
+  onAncestorOptionsChanged?: (options: Record<string, AncestorOption[]>) => void
+}
+
+export function useDatasetLoader({
+  id,
+  database,
+  identifier,
+  isDatabaseMode,
+  filters,
+  currentFiltersKey,
+  countBySelections,
+  countByReady,
+  getCountByCacheKey,
+  chartCountOverrides,
+  dashboardCharts,
+  getDashboardChartKey,
+  visibleDashboardKeys,
+  previousCountByRef,
+  onDatasetLoaded,
+  onAncestorOptionsChanged,
+}: UseDatasetLoaderArgs) {
+  const [dataset, setDataset] = useState<Dataset | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [columnMetadata, setColumnMetadata] = useState<Record<string, ColumnMetadata[]>>({})
+  const [aggregations, setAggregations] = useState<Record<string, Record<string, AggregationCacheEntry>>>({})
+  const [survivalCurves, setSurvivalCurves] = useState<Record<string, Record<string, SurvivalCacheEntry>>>({})
+  const [baselineAggregations, setBaselineAggregations] = useState<Record<string, ColumnAggregation[]>>({})
+  const [ancestorOptions, setAncestorOptions] = useState<Record<string, AncestorOption[]>>({})
+
+  const survivalRequests = useRef<Set<string>>(new Set())
+
+  // Derived values
+  const usesDatabaseAPI = isDatabaseMode ? true : dataset?.database_type === 'connected'
+  const databaseIdentifier = isDatabaseMode ? identifier : dataset?.database_name
+  const datasetIdentifier = dataset?.id
+
+  // ── Cache helpers ─────────────────────────────────────────────────
+
+  const isCacheEntryFresh = (entry?: { timestamp: number; filtersKey?: string }, filtersKey?: string) => {
+    if (!entry) return false
+    if (filtersKey && entry.filtersKey !== filtersKey) return false
+    return Date.now() - entry.timestamp < CACHE_TTL_MS
+  }
+
+  const getAggregationsForTable = (tableName: string, override?: string): ColumnAggregation[] | undefined => {
+    const cacheKey = getCountByCacheKey(tableName, override)
+    const entry = aggregations[tableName]?.[cacheKey]
+    if (!isCacheEntryFresh(entry, currentFiltersKey)) return undefined
+    return entry?.data
+  }
+
+  const getBaselineAggregation = (tableName: string, columnName: string): ColumnAggregation | undefined => {
+    const tableAggs = baselineAggregations[tableName]
+    if (!tableAggs) return undefined
+    return tableAggs.find(agg => agg.column_name === columnName)
+  }
+
+  const getAggregation = (tableName: string, columnName: string, overrideKey?: string): ColumnAggregation | undefined => {
+    const tableAggs = getAggregationsForTable(tableName, overrideKey)
+    if (!tableAggs) return undefined
+    return tableAggs.find(agg => agg.column_name === columnName)
+  }
+
+  const getColumnMetadata = (tableName: string, columnName: string): ColumnMetadata | undefined => {
+    const metadata = columnMetadata[tableName]
+    if (!metadata) return undefined
+    return metadata.find(col => col.column_name === columnName)
+  }
+
+  const getDisplayTitle = (tableName: string, columnName: string): string => {
+    const metadata = getColumnMetadata(tableName, columnName)
+    return metadata?.display_name || columnName.replace(/_/g, ' ')
+  }
+
+  // ── Display helpers ───────────────────────────────────────────────
+
+  const getTableDisplayNameByName = (tableName?: string): string | undefined => {
+    if (!tableName || !dataset?.tables) return tableName
+    const match = dataset.tables.find(t => t.name === tableName)
+    return match?.displayName || tableName
+  }
+
+  const getMetricLabels = (aggregation?: ColumnAggregation) => {
+    if (!aggregation || aggregation.metric_type !== 'parent' || !aggregation.metric_parent_table) {
+      return { short: 'rows', long: 'Rows' }
+    }
+    const parentName = getTableDisplayNameByName(aggregation.metric_parent_table) || aggregation.metric_parent_table
+    return {
+      short: `unique ${parentName.toLowerCase()}`,
+      long: `Unique ${parentName}`
+    }
+  }
+
+  const formatMetricPath = (aggregation?: ColumnAggregation): string | null => {
+    if (!aggregation || aggregation.metric_type !== 'parent' || !aggregation.metric_path || aggregation.metric_path.length === 0) {
+      return null
+    }
+    const target = aggregation.metric_parent_table
+    const targetLabel = target ? getTableDisplayNameByName(target) || target : ''
+    const chain = aggregation.metric_path
+      .map(segment => `${segment.from_table}.${segment.via_column}`)
+      .join(' → ')
+    return targetLabel ? `${targetLabel} via ${chain}` : chain
+  }
+
+  const getTableColor = (tableName: string): string => {
+    if (!dataset?.tables) return '#9E9E9E'
+    const tableIndex = dataset.tables.findIndex(t => t.name === tableName)
+    const colors = ['#2196F3', '#4CAF50', '#FF9800', '#9C27B0', '#F44336', '#00BCD4', '#FFC107', '#E91E63']
+    return tableIndex >= 0 ? colors[tableIndex % colors.length] : '#9E9E9E'
+  }
+
+  const getTableChartCount = (tableName: string): number => {
+    const tableAggs = baselineAggregations[tableName] || []
+    if (tableAggs.length === 0) return 0
+    return tableAggs.filter(agg => {
+      const meta = getColumnMetadata(tableName, agg.column_name)
+      return !meta?.is_hidden
+    }).length
+  }
+
+  // ── Filter helpers (need dataset) ─────────────────────────────────
+
+  const getAllEffectiveFilters = (): Record<string, { direct: Filter[]; propagated: Filter[] }> => {
+    if (!dataset) return {}
+    const result: Record<string, { direct: Filter[]; propagated: Filter[] }> = {}
+    for (const table of dataset.tables) {
+      result[table.name] = { direct: [], propagated: [] }
+    }
+    for (const filter of filters) {
+      const filterTableName = filter.tableName
+      if (!filterTableName) continue
+      for (const table of dataset.tables) {
+        if (table.name === filterTableName) {
+          result[table.name].direct.push(filter)
+        } else {
+          const path = findRelationshipPath(table.name, filterTableName, dataset.tables)
+          if (path !== null) {
+            result[table.name].propagated.push(filter)
+          }
+        }
+      }
+    }
+    return result
+  }
+
+  // ── Survival curve helpers ────────────────────────────────────────
+
+  const getSurvivalEntryKey = (timeColumn: string, statusColumn: string, cacheKey: string) =>
+    `${timeColumn}::${statusColumn}::${cacheKey}`
+
+  const getSurvivalCurve = (
+    tableName: string,
+    timeColumn: string,
+    statusColumn: string,
+    cacheKey?: string
+  ): SurvivalCurvePoint[] | undefined => {
+    const key = cacheKey ?? getCountByCacheKey(tableName)
+    const entryKey = getSurvivalEntryKey(timeColumn, statusColumn, key)
+    const entry = survivalCurves[tableName]?.[entryKey]
+    if (!isCacheEntryFresh(entry, currentFiltersKey)) return undefined
+    return entry?.data
+  }
+
+  const loadSurvivalCurve = async (
+    table: Table,
+    timeColumn: string,
+    statusColumn: string,
+    cacheKey?: string
+  ) => {
+    const key = cacheKey ?? getCountByCacheKey(table.name)
+    const entryKey = getSurvivalEntryKey(timeColumn, statusColumn, key)
+    const cached = survivalCurves[table.name]?.[entryKey]
+    if (isCacheEntryFresh(cached, currentFiltersKey)) return
+
+    const requestKey = `${table.name}|${entryKey}|${currentFiltersKey}`
+    if (survivalRequests.current.has(requestKey)) return
+    survivalRequests.current.add(requestKey)
+
+    try {
+      const params: Record<string, any> = { timeColumn, statusColumn }
+      if (filters.length > 0) {
+        params.filters = JSON.stringify(filters)
+      }
+      const selection = countBySelections[table.name]
+      if (selection?.mode === 'parent') {
+        params.countBy = `parent:${selection.targetTable}`
+      }
+
+      const response = await api.get(`/datasets/${identifier}/tables/${table.id}/survival`, { params })
+      setSurvivalCurves(prev => {
+        const tableCache = prev[table.name] || {}
+        const nextEntry: SurvivalCacheEntry = {
+          data: response.data.curve || [],
+          filtersKey: currentFiltersKey,
+          countByKey: key,
+          statusColumn,
+          timestamp: Date.now()
+        }
+        return {
+          ...prev,
+          [table.name]: { ...tableCache, [entryKey]: nextEntry }
+        }
+      })
+    } catch (error) {
+      console.error('Failed to load survival curve:', error)
+    } finally {
+      survivalRequests.current.delete(requestKey)
+    }
+  }
+
+  const ensureSurvivalCurve = (
+    table: Table,
+    timeColumn: string,
+    statusColumn: string,
+    cacheKey?: string
+  ) => {
+    const key = cacheKey ?? getCountByCacheKey(table.name)
+    const entryKey = getSurvivalEntryKey(timeColumn, statusColumn, key)
+    const cached = survivalCurves[table.name]?.[entryKey]
+    if (isCacheEntryFresh(cached, currentFiltersKey)) return
+    loadSurvivalCurve(table, timeColumn, statusColumn, key)
+  }
+
+  const findSurvivalStatusColumn = (tableName: string, timeColumn: string): string | null => {
+    const metadata = columnMetadata[tableName]
+    if (!metadata) return null
+    const statusColumns = metadata.filter(col => col.display_type === 'survival_status')
+    if (statusColumns.length === 0) return null
+    const base = timeColumn.replace(/_(months|days|time)$/i, '')
+    const matched = statusColumns.find(col => col.column_name.startsWith(base))
+    return (matched || statusColumns[0]).column_name
+  }
+
+  // ── Loading functions ─────────────────────────────────────────────
+
+  const loadTableAggregations = async (
+    tableId: string,
+    tableName: string,
+    options?: {
+      storeBaseline?: boolean
+      useDbAPI?: boolean
+      dbName?: string
+      datasetId?: string
+      tableFilters?: Filter[]
+      cacheKey?: string
+      selectionOverride?: CountBySelection | null
+    }
+  ) => {
+    try {
+      const activeFilters = options?.tableFilters !== undefined ? options.tableFilters : filters
+      const requestFiltersKey = buildFiltersKey(activeFilters)
+      const params: Record<string, any> = activeFilters.length > 0 ? { filters: JSON.stringify(activeFilters) } : {}
+      const shouldUseDbAPI = options?.useDbAPI !== undefined ? options.useDbAPI : usesDatabaseAPI
+      const dbId = options?.dbName || databaseIdentifier
+      const datasetParam = options?.datasetId || datasetIdentifier
+
+      const apiPath = shouldUseDbAPI
+        ? `/databases/${dbId}/tables/${tableId}/aggregations`
+        : `/datasets/${identifier}/tables/${tableId}/aggregations`
+      if (shouldUseDbAPI && datasetParam) {
+        params.datasetId = datasetParam
+      }
+      const selection = options?.selectionOverride ?? countBySelections[tableName]
+      const cacheKey = options?.cacheKey ?? getCountByCacheKey(tableName)
+      if (selection?.mode === 'parent') {
+        params.countBy = `parent:${selection.targetTable}`
+      }
+
+      const response = await api.get(apiPath, { params })
+      setAggregations(prev => {
+        const previousTableCache = prev[tableName] || {}
+        const nextEntry: AggregationCacheEntry = {
+          data: response.data.aggregations,
+          filtersKey: requestFiltersKey,
+          timestamp: Date.now()
+        }
+        const nextTableCache: Record<string, AggregationCacheEntry> = {
+          ...previousTableCache,
+          [cacheKey]: nextEntry
+        }
+
+        const tableKeys = Object.keys(nextTableCache)
+        if (tableKeys.length > CACHE_MAX_ENTRIES_PER_TABLE) {
+          const sortedByAge = tableKeys
+            .slice()
+            .sort((a, b) => nextTableCache[a].timestamp - nextTableCache[b].timestamp)
+          while (sortedByAge.length > CACHE_MAX_ENTRIES_PER_TABLE) {
+            const oldestKey = sortedByAge.shift()
+            if (oldestKey) {
+              delete nextTableCache[oldestKey]
+            }
+          }
+        }
+
+        return { ...prev, [tableName]: nextTableCache }
+      })
+      if (options?.storeBaseline && cacheKey === ROW_COUNT_KEY) {
+        setBaselineAggregations(prev => ({ ...prev, [tableName]: response.data.aggregations }))
+      }
+    } catch (err) {
+      console.error('Failed to load table aggregations:', err)
+      setError(err instanceof Error ? err.message : 'Failed to load table aggregations')
+    }
+  }
+
+  const loadColumnMetadata = async (
+    tableId: string,
+    tableName: string,
+    options?: { useDbAPI?: boolean; dbName?: string; datasetId?: string }
+  ) => {
+    try {
+      const shouldUseDbAPI = options?.useDbAPI !== undefined ? options.useDbAPI : usesDatabaseAPI
+      const dbId = options?.dbName || databaseIdentifier
+      const datasetParam = options?.datasetId || datasetIdentifier
+
+      const apiPath = shouldUseDbAPI
+        ? `/databases/${dbId}/tables/${tableId}/columns`
+        : `/datasets/${identifier}/tables/${tableId}/columns`
+      const response = await api.get(apiPath, {
+        params: shouldUseDbAPI && datasetParam ? { datasetId: datasetParam } : undefined
+      })
+      setColumnMetadata(prev => ({ ...prev, [tableName]: response.data.columns }))
+    } catch (err) {
+      console.error('Failed to load column metadata:', err)
+      setError(err instanceof Error ? err.message : 'Failed to load column metadata')
+    }
+  }
+
+  const reloadAggregations = useCallback(async () => {
+    if (!dataset || !countByReady) return
+    const shouldUseDbAPI = isDatabaseMode || dataset.database_type === 'connected'
+    const dbId = isDatabaseMode ? identifier : dataset.database_name
+
+    for (const table of dataset.tables) {
+      const selection = countBySelections[table.name] ?? null
+      const cacheKey = getCountByCacheKey(table.name)
+      await loadTableAggregations(table.id, table.name, {
+        useDbAPI: shouldUseDbAPI,
+        dbName: dbId,
+        datasetId: dataset.id,
+        tableFilters: filters,
+        cacheKey,
+        selectionOverride: selection
+      })
+    }
+  }, [dataset, countByReady, isDatabaseMode, identifier, filters, countBySelections])
+
+  const ensureAggregationForCacheKey = (tableName: string, cacheKey: string) => {
+    const cachedEntry = aggregations[tableName]?.[cacheKey]
+    if (isCacheEntryFresh(cachedEntry, currentFiltersKey)) return
+    if (!dataset) return
+
+    const shouldUseDbAPI = isDatabaseMode || dataset.database_type === 'connected'
+    const dbId = isDatabaseMode ? identifier : dataset.database_name
+    const table = dataset.tables.find(t => t.name === tableName)
+    if (!table) return
+
+    const selection = cacheKey.startsWith('parent:')
+      ? { mode: 'parent' as const, targetTable: cacheKey.slice('parent:'.length) }
+      : null
+    loadTableAggregations(table.id, table.name, {
+      useDbAPI: shouldUseDbAPI,
+      dbName: dbId,
+      datasetId: dataset.id,
+      cacheKey,
+      selectionOverride: selection
+    })
+  }
+
+  const loadDataset = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      setAggregations({})
+      setBaselineAggregations({})
+
+      const apiPath = isDatabaseMode ? `/databases/${identifier}` : `/datasets/${identifier}`
+      const response = await api.get(apiPath)
+
+      const loadedDataset = response.data.dataset
+      setDataset(loadedDataset)
+      setBaselineAggregations({})
+      onDatasetLoaded()
+
+      const shouldUseDbAPI = isDatabaseMode || loadedDataset.database_type === 'connected'
+      const dbId = isDatabaseMode ? identifier : loadedDataset.database_name
+
+      for (const table of loadedDataset.tables) {
+        await loadTableAggregations(table.id, table.name, {
+          storeBaseline: true,
+          useDbAPI: shouldUseDbAPI,
+          dbName: dbId,
+          datasetId: loadedDataset.id,
+          cacheKey: ROW_COUNT_KEY
+        })
+        await loadColumnMetadata(table.id, table.name, {
+          useDbAPI: shouldUseDbAPI,
+          dbName: dbId,
+          datasetId: loadedDataset.id
+        })
+      }
+    } catch (err) {
+      console.error('Failed to load dataset:', err)
+      setError(err instanceof Error ? err.message : 'Failed to load dataset')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // ── Effects ───────────────────────────────────────────────────────
+
+  // Load dataset when countBy is ready
+  useEffect(() => {
+    if (!countByReady) return
+    loadDataset()
+  }, [id, database, countByReady])
+
+  // Build ancestor options when dataset changes
+  useEffect(() => {
+    if (!dataset?.tables) {
+      setAncestorOptions({})
+      return
+    }
+    let cancelled = false
+    const tablesSnapshot = dataset.tables
+    Promise.resolve().then(() => {
+      if (cancelled) return
+      const options = buildAncestorOptions(tablesSnapshot)
+      if (cancelled) return
+      setAncestorOptions(options)
+    })
+    return () => { cancelled = true }
+  }, [dataset])
+
+  // Normalize countBy selections when ancestor options change (via callback)
+  useEffect(() => {
+    if (Object.keys(ancestorOptions).length === 0) return
+    onAncestorOptionsChanged?.(ancestorOptions)
+  }, [ancestorOptions])
+
+  // Reload aggregations when filters change
+  useEffect(() => {
+    if (dataset && countByReady) {
+      reloadAggregations()
+    }
+  }, [filters, dataset, countByReady])
+
+  // Reload when countBy selections change
+  useEffect(() => {
+    if (!dataset || !countByReady) return
+
+    const shouldUseDbAPI = isDatabaseMode || dataset.database_type === 'connected'
+    const dbId = isDatabaseMode ? identifier : dataset.database_name
+
+    dataset.tables.forEach(table => {
+      const previousKey = previousCountByRef.current[table.name]
+        ? `parent:${previousCountByRef.current[table.name].targetTable}`
+        : 'rows'
+      const currentSelection = countBySelections[table.name]
+      const currentKey = currentSelection ? `parent:${currentSelection.targetTable}` : 'rows'
+
+      if (previousKey !== currentKey) {
+        const cachedEntry = aggregations[table.name]?.[currentKey]
+        if (isCacheEntryFresh(cachedEntry, currentFiltersKey)) return
+        loadTableAggregations(table.id, table.name, {
+          useDbAPI: shouldUseDbAPI,
+          dbName: dbId,
+          datasetId: dataset.id,
+          cacheKey: currentKey
+        })
+      }
+    })
+
+    previousCountByRef.current = countBySelections
+  }, [countBySelections, dataset, isDatabaseMode, identifier, aggregations, currentFiltersKey])
+
+  // Ensure aggregations for chart count overrides
+  useEffect(() => {
+    if (!dataset || !countByReady) return
+    Object.entries(chartCountOverrides).forEach(([key, cacheKey]) => {
+      const [tableName, columnName] = key.split('.')
+      if (tableName && columnName) {
+        ensureAggregationForCacheKey(tableName, cacheKey)
+      }
+    })
+  }, [chartCountOverrides, dataset, countByReady])
+
+  // Reload for visible dashboard charts
+  useEffect(() => {
+    if (!dataset || !countByReady) return
+    const shouldUseDbAPI = isDatabaseMode || dataset.database_type === 'connected'
+    const dbId = isDatabaseMode ? identifier : dataset.database_name
+
+    dashboardCharts.forEach(chart => {
+      const key = getDashboardChartKey(chart)
+      if (!visibleDashboardKeys[key]) return
+      const table = dataset.tables.find(t => t.name === chart.tableName)
+      if (!table) return
+      const cacheKey = chart.countByTarget ? `parent:${chart.countByTarget}` : ROW_COUNT_KEY
+      const cachedEntry = aggregations[chart.tableName]?.[cacheKey]
+      if (isCacheEntryFresh(cachedEntry, currentFiltersKey)) return
+      loadTableAggregations(table.id, table.name, {
+        useDbAPI: shouldUseDbAPI,
+        dbName: dbId,
+        datasetId: dataset.id,
+        cacheKey,
+        selectionOverride: chart.countByTarget ? { mode: 'parent', targetTable: chart.countByTarget } : null
+      })
+    })
+  }, [dashboardCharts, dataset, countByReady, aggregations, isDatabaseMode, identifier, currentFiltersKey, visibleDashboardKeys])
+
+  return {
+    dataset,
+    loading,
+    error,
+    columnMetadata,
+    aggregations,
+    baselineAggregations,
+    ancestorOptions,
+    isCacheEntryFresh,
+    getAggregationsForTable,
+    getBaselineAggregation,
+    getAggregation,
+    getColumnMetadata,
+    getDisplayTitle,
+    getTableDisplayNameByName,
+    getMetricLabels,
+    formatMetricPath,
+    getTableColor,
+    getTableChartCount,
+    getAllEffectiveFilters,
+    getSurvivalCurve,
+    ensureSurvivalCurve,
+    findSurvivalStatusColumn,
+    ensureAggregationForCacheKey,
+  }
+}

--- a/client/src/pages/DatasetExplorer/hooks/useFilterState.ts
+++ b/client/src/pages/DatasetExplorer/hooks/useFilterState.ts
@@ -1,0 +1,355 @@
+import { useState, useEffect, useRef } from 'react'
+import {
+  type Filter,
+  ROW_COUNT_KEY,
+  unwrapNot,
+  rangeKey,
+  rangesEqual,
+  getFilterCountKey,
+  filterContainsColumn,
+  migrateFiltersToCurrentSchema,
+} from '../../../utils/filterHelpers'
+import {
+  normalizeFilterValue,
+  buildFiltersKey,
+  deserializeFilters,
+} from '../utils'
+
+interface UseFilterStateArgs {
+  identifier: string | undefined
+}
+
+export function useFilterState({ identifier }: UseFilterStateArgs) {
+  const [filters, setFilters] = useState<Filter[]>([])
+  const [activeFilterMenu, setActiveFilterMenu] = useState<{ tableName: string; columnName: string; countKey?: string } | null>(null)
+  const [customRangeInputs, setCustomRangeInputs] = useState<Record<string, { min: string; max: string }>>({})
+  const [rangeSelections, setRangeSelections] = useState<Record<string, Array<{ start: number; end: number }>>>({})
+
+  const filtersInitialized = useRef(false)
+
+  // Restore filters from URL hash / localStorage on mount
+  useEffect(() => {
+    if (filtersInitialized.current) return
+
+    const hash = window.location.hash
+    const match = hash.match(/filters=([^&]+)/)
+    const encodedFilters = match ? match[1] : null
+
+    if (encodedFilters) {
+      const restored = deserializeFilters(encodedFilters)
+      if (restored && restored.length > 0) {
+        setFilters(migrateFiltersToCurrentSchema(restored))
+        filtersInitialized.current = true
+        return
+      }
+    }
+
+    // Fallback to localStorage
+    try {
+      const stored = localStorage.getItem(`filters_${identifier}`)
+      if (stored) {
+        const parsed: Filter[] = JSON.parse(stored)
+        if (parsed.length > 0) {
+          setFilters(migrateFiltersToCurrentSchema(parsed))
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load filters from localStorage:', error)
+    }
+
+    filtersInitialized.current = true
+  }, [identifier])
+
+  // ── Filter persistence helpers ────────────────────────────────────
+
+  const saveFiltersToLocalStorage = (filterList: Filter[]) => {
+    try {
+      localStorage.setItem(`filters_${identifier}`, JSON.stringify(filterList))
+    } catch (error) {
+      console.error('Failed to save filters to localStorage:', error)
+    }
+  }
+
+  // ── Filter manipulation functions ─────────────────────────────────
+
+  const getFilterTableNameForCacheKey = (filter: Filter): string | undefined => filter.tableName
+
+  const hasColumnFilter = (column: string, countKey?: string): boolean => {
+    const resolvedKey = countKey ?? ROW_COUNT_KEY
+    return filters.some(f => {
+      const actual = unwrapNot(f)
+      if (!actual || !filterContainsColumn(actual, column)) return false
+      return getFilterCountKey(f) === resolvedKey
+    })
+  }
+
+  const removeColumnFilters = (prev: Filter[], column: string, countKey?: string): Filter[] => {
+    const resolvedKey = countKey ?? ROW_COUNT_KEY
+    return prev.filter(filter => {
+      const actualFilter = unwrapNot(filter)
+      if (!actualFilter || !filterContainsColumn(actualFilter, column)) return true
+      return getFilterCountKey(filter) !== resolvedKey
+    })
+  }
+
+  const clearColumnFilter = (tableName: string, columnName: string, countKey?: string) => {
+    setFilters(prev => removeColumnFilters(prev, columnName, countKey))
+    const key = rangeKey(tableName, columnName, countKey)
+    setCustomRangeInputs(prev => {
+      if (!(key in prev)) return prev
+      const { [key]: _removed, ...rest } = prev
+      return rest
+    })
+    setRangeSelections(prev => {
+      if (!(key in prev)) return prev
+      const { [key]: _removed, ...rest } = prev
+      return rest
+    })
+  }
+
+  const updateColumnRanges = (
+    tableName: string,
+    columnName: string,
+    updater: (ranges: Array<{ start: number; end: number }>) => Array<{ start: number; end: number }>,
+    countKey?: string
+  ) => {
+    const key = rangeKey(tableName, columnName, countKey)
+    let nextRanges: Array<{ start: number; end: number }> = []
+    setRangeSelections(prev => {
+      const prevRanges = prev[key] ?? []
+      nextRanges = updater(prevRanges)
+      nextRanges = nextRanges
+        .slice()
+        .sort((a, b) => (a.start - b.start) || (a.end - b.end))
+      const unchanged = prevRanges.length === nextRanges.length && prevRanges.every((range, idx) => rangesEqual(range, nextRanges[idx]))
+      if (unchanged) {
+        nextRanges = prevRanges
+        return prev
+      }
+      const updated = { ...prev }
+      if (nextRanges.length === 0) {
+        delete updated[key]
+      } else {
+        updated[key] = nextRanges
+      }
+      return updated
+    })
+
+    setFilters(prev => {
+      const without = removeColumnFilters(prev, columnName, countKey)
+      if (nextRanges.length === 0) return without
+      if (nextRanges.length === 1) {
+        const range = nextRanges[0]
+        return [
+          ...without,
+          {
+            column: columnName,
+            operator: 'between',
+            value: [range.start, range.end],
+            tableName,
+            countByKey: countKey
+          }
+        ]
+      }
+      const orFilters = nextRanges.map(range => ({ column: columnName, operator: 'between' as const, value: [range.start, range.end] }))
+      return [
+        ...without,
+        { column: columnName, or: orFilters, tableName, countByKey: countKey }
+      ]
+    })
+  }
+
+  const toggleFilter = (column: string, value: string | number, tableName?: string, countByKey?: string) => {
+    const filterValue = normalizeFilterValue(value)
+    const resolvedCountKey = countByKey ?? ROW_COUNT_KEY
+
+    setFilters(prevFilters => {
+      const nextFilters = [...prevFilters]
+
+      const existingIndex = nextFilters.findIndex(f => {
+        const actualFilter = unwrapNot(f)
+        if (!actualFilter || actualFilter.column !== column) return false
+        return getFilterCountKey(f) === resolvedCountKey
+      })
+
+      const applyMetadata = (target: Filter, source?: Filter) => {
+        if (tableName) {
+          target.tableName = tableName
+        } else if (source?.tableName) {
+          target.tableName = source.tableName
+        }
+        target.countByKey = resolvedCountKey
+      }
+
+      if (existingIndex === -1) {
+        const newFilter: Filter = { column, operator: 'eq', value: filterValue }
+        applyMetadata(newFilter)
+        nextFilters.push(newFilter)
+        return nextFilters
+      }
+
+      const existingWrapped = nextFilters[existingIndex]
+      const isNot = !!existingWrapped.not
+      const existing = isNot && existingWrapped.not ? existingWrapped.not : existingWrapped
+
+      if (existing.operator === 'eq') {
+        const existingValue = normalizeFilterValue(existing.value as string | number)
+        if (existingValue === filterValue) {
+          nextFilters.splice(existingIndex, 1)
+          return nextFilters
+        }
+
+        const updatedFilter: Filter = {
+          column,
+          operator: 'in',
+          value: [existingValue, filterValue]
+        }
+        applyMetadata(updatedFilter, existing)
+        nextFilters[existingIndex] = isNot ? { not: updatedFilter } : updatedFilter
+        return nextFilters
+      }
+
+      if (existing.operator === 'in') {
+        const values = Array.isArray(existing.value)
+          ? existing.value.map(v => normalizeFilterValue(v as string | number))
+          : []
+        const matchIndex = values.findIndex(v => v === filterValue)
+
+        if (matchIndex >= 0) {
+          values.splice(matchIndex, 1)
+        } else {
+          values.push(filterValue)
+        }
+
+        if (values.length === 0) {
+          nextFilters.splice(existingIndex, 1)
+        } else if (values.length === 1) {
+          const updatedFilter: Filter = { column, operator: 'eq', value: values[0] }
+          applyMetadata(updatedFilter, existing)
+          nextFilters[existingIndex] = isNot ? { not: updatedFilter } : updatedFilter
+        } else {
+          const updatedFilter: Filter = { column, operator: 'in', value: values }
+          applyMetadata(updatedFilter, existing)
+          nextFilters[existingIndex] = isNot ? { not: updatedFilter } : updatedFilter
+        }
+
+        return nextFilters
+      }
+
+      const updatedFilter: Filter = { column, operator: 'eq', value: filterValue }
+      applyMetadata(updatedFilter, existing)
+      nextFilters[existingIndex] = isNot ? { not: updatedFilter } : updatedFilter
+      return nextFilters
+    })
+  }
+
+  const clearFilters = () => {
+    setFilters([])
+    setCustomRangeInputs({})
+    setRangeSelections({})
+  }
+
+  const isValueFiltered = (column: string, value: string | number, countByKey?: string): boolean => {
+    const compareValue = normalizeFilterValue(value)
+    const resolvedKey = countByKey ?? ROW_COUNT_KEY
+    return filters.some(f => {
+      const actualFilter = unwrapNot(f)
+      if (!actualFilter || actualFilter.column !== column) return false
+      if (getFilterCountKey(f) !== resolvedKey) return false
+      if (actualFilter.operator === 'eq') {
+        return normalizeFilterValue(actualFilter.value as string | number) === compareValue
+      }
+      if (actualFilter.operator === 'in' && Array.isArray(actualFilter.value)) {
+        return actualFilter.value
+          .map(v => normalizeFilterValue(v as string | number))
+          .includes(compareValue)
+      }
+      return false
+    })
+  }
+
+  const toggleRangeFilter = (tableName: string, column: string, binStart: number, binEnd: number, countKey?: string) => {
+    const range = { start: binStart, end: binEnd }
+    updateColumnRanges(tableName, column, prevRanges => {
+      const existingIndex = prevRanges.findIndex(r => rangesEqual(r, range))
+      if (existingIndex >= 0) {
+        return [...prevRanges.slice(0, existingIndex), ...prevRanges.slice(existingIndex + 1)]
+      }
+      return [...prevRanges, range]
+    }, countKey)
+  }
+
+  const isRangeFiltered = (tableName: string, column: string, binStart: number, binEnd: number, countKey?: string): boolean => {
+    const key = rangeKey(tableName, column, countKey)
+    const ranges = rangeSelections[key] ?? []
+    return ranges.some(range => rangesEqual(range, { start: binStart, end: binEnd }))
+  }
+
+  const handleCustomRangeChange = (
+    key: string,
+    field: 'min' | 'max',
+    value: string
+  ) => {
+    setCustomRangeInputs(prev => ({
+      ...prev,
+      [key]: {
+        min: field === 'min' ? value : prev[key]?.min ?? '',
+        max: field === 'max' ? value : prev[key]?.max ?? ''
+      }
+    }))
+  }
+
+  const applyCustomRange = (tableName: string, columnName: string, countKey?: string) => {
+    const key = rangeKey(tableName, columnName, countKey)
+    const range = customRangeInputs[key]
+    if (!range) return
+
+    const min = range.min.trim()
+    const max = range.max.trim()
+    if (min === '' || max === '') return
+
+    const minValue = Number(min)
+    const maxValue = Number(max)
+    if (!Number.isFinite(minValue) || !Number.isFinite(maxValue) || minValue > maxValue) {
+      return
+    }
+
+    setCustomRangeInputs(prev => ({
+      ...prev,
+      [key]: { min: String(minValue), max: String(maxValue) }
+    }))
+
+    updateColumnRanges(tableName, columnName, prevRanges => {
+      const nextRange = { start: minValue, end: maxValue }
+      const existingIndex = prevRanges.findIndex(r => rangesEqual(r, nextRange))
+      if (existingIndex >= 0) return prevRanges
+      return [...prevRanges, nextRange]
+    }, countKey)
+  }
+
+  return {
+    filters,
+    setFilters,
+    filtersInitialized,
+    currentFiltersKey: buildFiltersKey(filters),
+    activeFilterMenu,
+    setActiveFilterMenu,
+    customRangeInputs,
+    setCustomRangeInputs,
+    rangeSelections,
+    setRangeSelections,
+    toggleFilter,
+    clearFilters,
+    isValueFiltered,
+    hasColumnFilter,
+    removeColumnFilters,
+    clearColumnFilter,
+    updateColumnRanges,
+    toggleRangeFilter,
+    isRangeFiltered,
+    handleCustomRangeChange,
+    applyCustomRange,
+    getFilterTableNameForCacheKey,
+    saveFiltersToLocalStorage,
+  }
+}

--- a/client/src/pages/DatasetExplorer/utils.ts
+++ b/client/src/pages/DatasetExplorer/utils.ts
@@ -1,0 +1,235 @@
+import type { MetricPathSegment } from '../../types'
+import type { Filter } from '../../utils/filterHelpers'
+import { encodeState, decodeState } from '../../utils/urlHelpers'
+import {
+  MAX_ANCESTOR_DEPTH,
+  type ColumnAggregation,
+  type Table,
+  type AncestorOption,
+  type HistogramBin,
+  type NumericStats,
+} from './types'
+import type { CountBySelection } from '../../utils/presetHelpers'
+
+// ── Pure utility functions (no React state dependencies) ────────────
+
+export const chartKey = (tableName: string, columnName: string) => `${tableName}.${columnName}`
+
+export const targetFromCacheKey = (key?: string): string | null => {
+  if (!key) return null
+  return key.startsWith('parent:') ? key.slice('parent:'.length) : null
+}
+
+export const parseSelectionFromCacheKey = (key?: string): CountBySelection | null => {
+  if (!key) return null
+  if (key.startsWith('parent:')) {
+    return { mode: 'parent', targetTable: key.slice('parent:'.length) }
+  }
+  return null
+}
+
+export const normalizeFilterValue = (value: string | number | null | undefined): string => {
+  if (value === null || value === undefined) return ''
+  return String(value)
+}
+
+export const formatRangeValue = (value: number): string => {
+  if (!Number.isFinite(value)) return '–'
+  if (Number.isInteger(value)) return value.toString()
+  return value.toFixed(2)
+}
+
+export const buildFiltersKey = (list?: Filter[]): string => JSON.stringify(list ?? [])
+
+export const metricsMatch = (a?: ColumnAggregation, b?: ColumnAggregation) => {
+  if (!a || !b) return false
+  const typeA = a.metric_type || 'rows'
+  const typeB = b.metric_type || 'rows'
+  if (typeA !== typeB) return false
+  if (typeA === 'parent') {
+    const pathA = JSON.stringify(a.metric_path || [])
+    const pathB = JSON.stringify(b.metric_path || [])
+    return a.metric_parent_table === b.metric_parent_table && pathA === pathB
+  }
+  return true
+}
+
+// ── Serialization helpers ───────────────────────────────────────────
+
+export const serializeFilters = (filters: Filter[]): string => encodeState(filters)
+
+export const deserializeFilters = (encoded: string): Filter[] | null => decodeState<Filter[]>(encoded)
+
+export const serializeCountBySelections = (selections: Record<string, CountBySelection>): string =>
+  encodeState(selections)
+
+export const deserializeCountBySelections = (encoded: string): Record<string, CountBySelection> | null =>
+  decodeState<Record<string, CountBySelection>>(encoded)
+
+// ── Ancestor options (graph traversal) ──────────────────────────────
+
+export const buildAncestorOptions = (tables: Table[]): Record<string, AncestorOption[]> => {
+  const tableMap = new Map(tables.map(t => [t.name, t]))
+  const options: Record<string, AncestorOption[]> = {}
+
+  tables.forEach(source => {
+    const result: AncestorOption[] = []
+    const queue: Array<{ tableName: string; path: MetricPathSegment[] }> = [{ tableName: source.name, path: [] }]
+    const visited = new Set<string>([source.name])
+
+    while (queue.length > 0) {
+      const { tableName, path } = queue.shift()!
+      const tableMeta = tableMap.get(tableName)
+      if (!tableMeta) continue
+
+      for (const rel of tableMeta.relationships || []) {
+        const nextTable = rel.referenced_table
+        const segment: MetricPathSegment = { from_table: tableName, via_column: rel.foreign_key, to_table: nextTable }
+        const nextPath = [...path, segment]
+
+        if (nextPath.length > MAX_ANCESTOR_DEPTH) {
+          continue
+        }
+
+        if (!visited.has(nextTable)) {
+          queue.push({ tableName: nextTable, path: nextPath })
+          visited.add(nextTable)
+        }
+
+        if (nextPath.length > 0) {
+          const targetMeta = tableMap.get(nextTable)
+          const labelParts = nextPath.map(seg => `${seg.from_table}.${seg.via_column}`)
+          const label = `${targetMeta?.displayName || targetMeta?.name || nextTable} via ${labelParts.join(' → ')}`
+          const key = `parent:${nextTable}`
+          result.push({ targetTable: nextTable, label, key, path: nextPath })
+        }
+      }
+    }
+
+    const unique = new Map<string, AncestorOption>()
+    result.forEach(option => {
+      if (!unique.has(option.targetTable)) {
+        unique.set(option.targetTable, option)
+      }
+    })
+    options[source.name] = Array.from(unique.values()).sort((a, b) => a.label.localeCompare(b.label))
+  })
+
+  return options
+}
+
+export const normalizeCountBySelections = (
+  selections: Record<string, CountBySelection>,
+  options: Record<string, AncestorOption[]>
+): Record<string, CountBySelection> => {
+  let changed = false
+  const next: Record<string, CountBySelection> = {}
+
+  Object.entries(selections).forEach(([table, selection]) => {
+    if (!selection) return
+    const tableOptions = options[table]
+    if (!tableOptions || tableOptions.length === 0) {
+      changed = true
+      return
+    }
+    const match = tableOptions.find(opt => opt.targetTable === selection.targetTable)
+    if (!match) {
+      changed = true
+      return
+    }
+    next[table] = selection
+  })
+
+  return changed ? next : selections
+}
+
+// ── Histogram binning ───────────────────────────────────────────────
+
+export const getNiceBinWidth = (range: number, desiredBins: number): number => {
+  if (!Number.isFinite(range) || range <= 0) {
+    return 1
+  }
+
+  const target = range / Math.max(desiredBins, 1)
+  if (!Number.isFinite(target) || target <= 0) {
+    return range
+  }
+
+  const exponent = Math.floor(Math.log10(target))
+  const scaled = target / Math.pow(10, exponent)
+
+  let niceScaled: number
+  if (scaled <= 1) {
+    niceScaled = 1
+  } else if (scaled <= 2) {
+    niceScaled = 2
+  } else if (scaled <= 5) {
+    niceScaled = 5
+  } else {
+    niceScaled = 10
+  }
+
+  return niceScaled * Math.pow(10, exponent)
+}
+
+export const getDisplayHistogram = (
+  histogram: HistogramBin[] | undefined,
+  stats: NumericStats | undefined
+): HistogramBin[] => {
+  if (!histogram || histogram.length === 0) return []
+  if (!stats || stats.min === null || stats.max === null) return histogram
+
+  const min = stats.min
+  const max = stats.max
+  if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) return histogram
+
+  const originalTotal = histogram.reduce((sum, bin) => sum + bin.count, 0)
+  if (!Number.isFinite(originalTotal) || originalTotal === 0) return histogram
+
+  const range = max - min
+  const desiredBins = Math.min(Math.max(histogram.length, 1), 60)
+  let width = getNiceBinWidth(range, desiredBins)
+  if (!Number.isFinite(width) || width <= 0) {
+    width = range || 1
+  }
+
+  let guard = 0
+  while (range / width > 60 && guard < 10) {
+    const nextApprox = Math.ceil(range / width / 2)
+    width = getNiceBinWidth(range, Math.max(nextApprox, 1))
+    if (!Number.isFinite(width) || width <= 0) {
+      width = range || 1
+      break
+    }
+    guard += 1
+  }
+
+  const start = Math.floor(min / width) * width
+  const bucketCount = Math.max(1, Math.ceil((max - start) / width) + 1)
+  const buckets: HistogramBin[] = []
+  for (let i = 0; i < bucketCount; i++) {
+    buckets.push({
+      bin_start: start + i * width,
+      bin_end: start + (i + 1) * width,
+      count: 0,
+      percentage: 0
+    })
+  }
+
+  histogram.forEach(bin => {
+    const center = (bin.bin_start + bin.bin_end) / 2
+    let index = Math.floor((center - start) / width)
+    if (index < 0) index = 0
+    if (index >= buckets.length) index = buckets.length - 1
+    buckets[index].count += bin.count
+  })
+
+  const rebinnedTotal = buckets.reduce((sum, bucket) => sum + bucket.count, 0)
+  const denominator = rebinnedTotal > 0 ? rebinnedTotal : originalTotal
+  buckets.forEach(bucket => {
+    bucket.percentage = denominator > 0 ? (bucket.count / denominator) * 100 : 0
+  })
+
+  const filtered = buckets.filter(bucket => bucket.count > 0)
+  return filtered.length > 0 ? filtered : histogram
+}


### PR DESCRIPTION
## Summary
- **Phase 5** of the DatasetExplorer refactoring epic (#92), completing the decomposition
- Extracted 3 new hooks (`useFilterState`, `useCountBy`, `useDatasetLoader`) and a `utils.ts` module with pure utility functions
- Deleted 97-line dead `renderCountIndicator` function (replaced by `<CountIndicator>` component)
- Reduced `DatasetExplorer.tsx` from 1,926 → 624 lines (-68%)
- **Cumulative across all 5 phases: 6,175 → 624 lines (-90%)**
- Added 66 new unit tests (163 → 229 client tests)
- Updated CORE.md with DatasetExplorer architecture documentation

### New files
| File | Lines | Purpose |
|------|-------|---------|
| `utils.ts` | 236 | Pure functions: histogram binning, serialization, ancestor graph traversal |
| `hooks/useFilterState.ts` | 356 | Filter state management, toggle/clear/range operations, URL restore |
| `hooks/useCountBy.ts` | 162 | Count-by selections, chart overrides, localStorage persistence |
| `hooks/useDatasetLoader.ts` | 578 | Dataset loading, aggregation caching, survival curves, display helpers |
| `__tests__/utils.test.ts` | 237 | 37 tests for utility functions |
| `hooks/__tests__/useFilterState.test.ts` | 179 | 15 tests for filter state hook |
| `hooks/__tests__/useCountBy.test.ts` | 158 | 14 tests for count-by hook |

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [x] All 229 client tests pass (163 existing + 66 new)
- [x] All 313 server tests pass
- [x] Existing `DatasetExplorer.test.tsx` integration tests pass unchanged (ChartContext interface is stable)
- [x] Manual smoke test of dataset explorer UI

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)